### PR TITLE
Traceback on Patients when current user has Client role but is a Lab Contact

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Changelog
 
 **Fixed**
 
-- #38 Traceback on Patients when current user has Client role but is LabContact
+- #39 Traceback on Patients when current user has Client role but is LabContact
 - #36 Using parameter "vocabulary" wasn't working in bika_setup
 - #35 Analysis Request View error when the page redirects the user
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Fixed**
 
+- #38 Traceback on Patients when current user has Client role but is LabContact
 - #36 Using parameter "vocabulary" wasn't working in bika_setup
 - #35 Analysis Request View error when the page redirects the user
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changelog
 **Changed**
 
 - #33 #37 bika.lims to senaite.core distribution
+- #39 Improved performance for Patient listings
 
 **Fixed**
 

--- a/bika/health/browser/client/patients.py
+++ b/bika/health/browser/client/patients.py
@@ -25,11 +25,11 @@ class ClientPatientsView(PatientsView):
     def folderitems(self):
         folderitems = super(ClientPatientsView, self).folderitems()
 
-        # hide PrimaryReferrer column
+        # hide PrimaryReferrerTitle column
         new_states = []
         for x in self.review_states:
-            if 'getPrimaryReferrer' in x['columns']:
-                x['columns'].remove("getPrimaryReferrer")
+            if 'getPrimaryReferrerTitle' in x['columns']:
+                x['columns'].remove("getPrimaryReferrerTitle")
             new_states.append(x)
         self.review_states = new_states
 

--- a/bika/health/browser/client/patients.py
+++ b/bika/health/browser/client/patients.py
@@ -6,31 +6,18 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from bika.health.browser.patients.folder_view import PatientsView
-from Products.CMFCore.utils import getToolByName
-from bika.health.permissions import AddPatient
-from bika.lims import bikaMessageFactory as _b
+
 
 class ClientPatientsView(PatientsView):
 
     def __init__(self, context, request):
         super(ClientPatientsView, self).__init__(context, request)
+
         # Limit results to those patients that "belong" to this client
         self.contentFilter['getPrimaryReferrerUID'] = context.UID()
 
     def _initFormParams(self):
         super(ClientPatientsView, self)._initFormParams()
-        if _b('Add') in self.context_actions:
-            self.context_actions[_b('Add')]['url'] = '../../patients/createObject?type_name=Patient'
 
-    def folderitems(self):
-        folderitems = super(ClientPatientsView, self).folderitems()
-
-        # hide PrimaryReferrerTitle column
-        new_states = []
-        for x in self.review_states:
-            if 'getPrimaryReferrerTitle' in x['columns']:
-                x['columns'].remove("getPrimaryReferrerTitle")
-            new_states.append(x)
-        self.review_states = new_states
-
-        return folderitems
+        # Remove PrimaryReferrerTitle column
+        self.remove_column('getPrimaryReferrerTitle')

--- a/bika/health/browser/insurancecompany/patients.py
+++ b/bika/health/browser/insurancecompany/patients.py
@@ -5,36 +5,17 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from bika.health.browser.patients.folder_view import PatientsView
-from bika.lims import bikaMessageFactory as _b
-from Products.CMFCore.utils import getToolByName
-
-""" This file contains overridden patient's functions to be used in insurance company's stuff.
-"""
+from bika.health.browser.patients.folder_view import PatientsView as BaseView
+from bika.lims import api
 
 
-class PatientsView(PatientsView):
+class PatientsView(BaseView):
 
-    def __init__(self, context, request):
-        super(PatientsView, self).__init__(context, request)
-
-    def _initFormParams(self):
-        super(PatientsView, self)._initFormParams()
-        if _b('Add') in self.context_actions:
-            # We need to create the new element in the patients original url to avoid a creation error.
-            self.context_actions[_b('Add')]['url'] = self.portal_url + '/patients/createObject?type_name=Patient'
-
-    def folderitems(self):
-        """ It filters patient's list by the current Insurance Company.
-        :return: A dict with the results filtered by Insurance Comp.
-        """
-        items = super(PatientsView, self).folderitems()
-        outitems = []
-        companyuid = self.context.UID()
-        for item in items:
-            if 'obj' in item and item.get('obj'):
-                pat = item.get('obj')
-                if pat.getInsuranceCompany() and \
-                   pat.getInsuranceCompany().UID() == companyuid:
-                    outitems.append(item)
-        return outitems
+    def isItemAllowed(self, obj):
+        # TODO: Performance tip. We need the full object to filter by Insurance
+        uid = api.get_uid(self.context)
+        full_obj = api.get_object(obj)
+        insurance_company = full_obj.getInsuranceCompany()
+        if not insurance_company:
+            return False
+        return api.get_uid(insurance_company) == uid

--- a/bika/health/browser/patients/folder_view.py
+++ b/bika/health/browser/patients/folder_view.py
@@ -25,7 +25,7 @@ COLUMNS = ['getPatientID',
            'getGender',
            'getAgeSplittedStr',
            'getBirthDate',
-           'getPrimaryReferrer']
+           'getPrimaryReferrerTitle']
 
 
 class PatientsView(BikaListingView):
@@ -48,16 +48,19 @@ class PatientsView(BikaListingView):
         self.show_select_column = False
 
         self.columns = {
-
             'Title': {
                 'title': _('Patient'),
-                'index': 'Title'},
+                'index': 'Title',
+                'replace_url': 'getURL'},
 
             'getPatientID': {
-                'title': _('Patient ID'), },
+                'title': _('Patient ID'),
+                'index': 'getPatientID',
+                'replace_url': 'getURL'},
 
             'getClientPatientID': {
                 'title': _('Client PID'),
+                'replace_url': 'getURL',
                 'sortable': False},
 
             'getGender': {
@@ -75,11 +78,11 @@ class PatientsView(BikaListingView):
                 'toggle': True,
                 'sortable': False},
 
-            'getPrimaryReferrer': {
+            'getPrimaryReferrerTitle': {
                 'title': _('Primary Referrer'),
+                'replace_url': 'getPrimaryReferrerURL',
                 'toggle': True,
                 'sortable': False},
-
         }
 
         self.review_states = [
@@ -128,7 +131,7 @@ class PatientsView(BikaListingView):
     def get_columns(self, sieve=None):
         """Get Table Columns and filter out keys listed in sieve
         """
-        if not sieve:
+        if sieve is None:
             sieve = list()
         if type(sieve) not in (types.ListType, types.TupleType):
             raise RuntimeError("Sieve must be a list type")
@@ -188,27 +191,7 @@ class PatientsView(BikaListingView):
                 the template
             :index: current index of the item
         """
-        if 'obj' not in item:
-            return None
-
-        item['getPatientID'] = obj.getPatientID
-        item['getGender'] = obj.getGender
-        item['getAgeSplittedStr'] = obj.getAgeSplittedStr
         item['getBirthDate'] = self.ulocalized_time(obj.getBirthDate)
-        item['getClientPatientID'] = obj.getClientPatientID
-        item['replace'][
-            'getPatientID'] = "<a href='%s/analysisrequests'>%s</a>" % \
-                              (item['url'], item['getPatientID'])
-        item['replace']['getClientPatientID'] = "<a href='%s'>%s</a>" % \
-                                                (item['url'],
-                                                 item['getClientPatientID'])
-        item['replace']['Title'] = "<a href='%s/analysisrequests'>%s</a>" % \
-                                   (item['url'], item['Title'])
-        prTitle = obj.getPrimaryReferrerTitle
-        prURL = obj.getPrimaryReferrerURL
-        item['getPrimaryReferrerTitle'] = prTitle
-        item['replace']['getPrimaryReferrer'] = \
-            "<a href='%s/analysisrequests'>%s</a>" % (prURL, prTitle)
         return item
 
     def folderitems(self):

--- a/bika/health/browser/patients/folder_view.py
+++ b/bika/health/browser/patients/folder_view.py
@@ -155,10 +155,13 @@ class PatientsView(BikaListingView):
             can_add_patients = member.id in owners
 
         if can_add_patients:
+            # TODO Performance tweak. Is this really needed?
             clients = self.context.clients.objectIds()
             if clients:
+                add_patient_url = '{}/patients/createObject?type_name=Patient'\
+                                  .format(self.portal_url)
                 self.context_actions[_b('Add')] = {
-                    'url': 'createObject?type_name=Patient',
+                    'url': add_patient_url,
                     'icon': '++resource++bika.lims.images/add.png'
                 }
             else:

--- a/bika/health/browser/patients/folder_view.py
+++ b/bika/health/browser/patients/folder_view.py
@@ -7,24 +7,16 @@
 
 import types
 
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
 from Products.CMFCore.utils import getToolByName
-from bika.lims import bikaMessageFactory as _b, api
-from bika.lims.content.contact import Contact
-from bika.lims.interfaces import IClient, ILabContact
 from bika.health import bikaMessageFactory as _
 from bika.health.catalog import CATALOG_PATIENT_LISTING
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.utils import logged_in_client
-from bika.health.config import PROJECTNAME
-from bika.health.interfaces import IPatients
 from bika.health.permissions import *
+from bika.lims import bikaMessageFactory as _b, api
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.interfaces import IClient, ILabContact
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
 from plone.app.layout.globals.interfaces import IViewView
 from zope.interface.declarations import implements
-import json
 
 # Available Columns of the Patients View Table (see: `get_columns`)
 COLUMNS = ['getPatientID',
@@ -49,7 +41,8 @@ class PatientsView(BikaListingView):
                               'sort_order': 'reverse'}
         self.context_actions = {}
         self.title = self.context.translate(_("Patients"))
-        self.icon = self.portal_url + "/++resource++bika.health.images/patient_big.png"
+        self.icon = '{}/++resource++bika.health.images/patient_big.png'.format(
+            self.portal_url)
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = False
@@ -132,9 +125,11 @@ class PatientsView(BikaListingView):
         client_uid = api.get_uid(client)
         self.contentFilter['getPrimaryReferrerUID'] = client_uid
 
-    def get_columns(self, sieve=[]):
+    def get_columns(self, sieve=None):
         """Get Table Columns and filter out keys listed in sieve
         """
+        if not sieve:
+            sieve = list()
         if type(sieve) not in (types.ListType, types.TupleType):
             raise RuntimeError("Sieve must be a list type")
         # filter out columns listed in sieve
@@ -164,22 +159,23 @@ class PatientsView(BikaListingView):
                     'icon': '++resource++bika.lims.images/add.png'
                 }
             else:
-                msg = _("Cannot create patients without any system clients configured.")
+                msg = _("Cannot create patients without any system clients "
+                        "configured.")
                 addPortalMessage(self.context.translate(msg))
 
         if mtool.checkPermission(ViewPatients, self.context):
-            self.review_states[0]['transitions'].append({'id':'deactivate'})
+            self.review_states[0]['transitions'].append({'id': 'deactivate'})
             self.review_states.append(
                 {'id': 'inactive',
                  'title': _b('Dormant'),
                  'contentFilter': {'inactive_state': 'inactive'},
-                 'transitions': [{'id':'activate'}, ],
+                 'transitions': [{'id': 'activate'}, ],
                  'columns': self.get_columns()})
             self.review_states.append(
                 {'id': 'all',
                  'title': _b('All'),
-                 'contentFilter':{},
-                 'transitions':[{'id':'empty'}, ],
+                 'contentFilter': {},
+                 'transitions': [{'id': 'empty'}, ],
                  'columns': self.get_columns()})
             stat = self.request.get("%s_review_state" % self.form_id, 'default')
             self.show_select_column = stat != 'all'
@@ -194,19 +190,20 @@ class PatientsView(BikaListingView):
         """
         if 'obj' not in item:
             return None
-        # TODO: Remember to use https://github.com/bikalabs/bika.lims/pull/1846/files#diff-40dfcc4bde98b3ea8f3d9f985776675aR51
-        # Note: attr and replace_url
+
         item['getPatientID'] = obj.getPatientID
         item['getGender'] = obj.getGender
         item['getAgeSplittedStr'] = obj.getAgeSplittedStr
         item['getBirthDate'] = self.ulocalized_time(obj.getBirthDate)
         item['getClientPatientID'] = obj.getClientPatientID
-        item['replace']['getPatientID'] = "<a href='%s/analysisrequests'>%s</a>" % \
-            (item['url'], item['getPatientID'])
+        item['replace'][
+            'getPatientID'] = "<a href='%s/analysisrequests'>%s</a>" % \
+                              (item['url'], item['getPatientID'])
         item['replace']['getClientPatientID'] = "<a href='%s'>%s</a>" % \
-            (item['url'], item['getClientPatientID'])
+                                                (item['url'],
+                                                 item['getClientPatientID'])
         item['replace']['Title'] = "<a href='%s/analysisrequests'>%s</a>" % \
-            (item['url'], item['Title'])
+                                   (item['url'], item['Title'])
         prTitle = obj.getPrimaryReferrerTitle
         prURL = obj.getPrimaryReferrerURL
         item['getPrimaryReferrerTitle'] = prTitle


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**This Pull Request depends on [Added get_user_contact function to api | senaite.core#573](https://github.com/senaite/senaite.core/pull/573)**

If the user logged in has the role Client assigned but is not a Contact from a Client (or does not have a Contact assigned), a Traceback is rised in Patients list. This Pull Request ensures the logged user a) has a Contact assigned, b) the Contact belongs to a Client and c) the Client exists. 

This Pull Request also improves the fetching of Patients by filtering them directly with a query (making use of `contentFilter`)

Linked issue: [Traceback on Patients when current user has Client role but is LabContact #38](https://github.com/senaite/senaite.health/issues/)

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.patients.folder_view, line 101, in __call__
  Module bika.lims.browser.bika_listing, line 939, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 158, in render
  Module chameleon.zpt.template, line 297, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module c4c6fb069f0fbbcb194c42bab3e2dfd4.py, line 443, in render
  Module c15fd9e387d03b0946bef279df9fe7ed.py, line 1449, in render_master
  Module c15fd9e387d03b0946bef279df9fe7ed.py, line 604, in render_content
  Module c4c6fb069f0fbbcb194c42bab3e2dfd4.py, line 364, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1379, in contents_table
  Module bika.lims.browser.bika_listing, line 1557, in __init__
  Module bika.health.browser.patients.folder_view, line 201, in folderitems
AttributeError: 'NoneType' object has no attribute 'UID'
```

## Desired behavior after PR is merged

No traceback is rised and the Patients are correctly filtered.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
