### PR TITLE
Create an Analysis Request from Sample View

### DIFF
--- a/bika/health/browser/analysisrequest/add.py
+++ b/bika/health/browser/analysisrequest/add.py
@@ -8,8 +8,10 @@
 from bika.lims.browser.analysisrequest.add import AnalysisRequestAddView as AnalysisRequestAddViewLIMS
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 import json
+from bika.lims.interfaces import IGetDefaultFieldValueARAddHook
 from Products.CMFCore.utils import getToolByName
 from bika.lims.browser.widgets import AddressWidget
+from zope.interface import implements
 
 
 class AnalysisRequestAddView(AnalysisRequestAddViewLIMS):
@@ -89,3 +91,26 @@ class AnalysisRequestAddView(AnalysisRequestAddViewLIMS):
                        inactive_state='active',
                        getCategoryUID=categoryuid)
         return services
+
+
+class GetDefaultFieldPatient(object):
+    """
+
+    """
+    implements(IGetDefaultFieldValueARAddHook)
+
+    def __init__(self, request):
+        self.request = request
+
+    def __call__(self, context):
+        if context is None:
+            return None
+        if context.portal_type == "Sample":
+            # TODO: Samples should be related to patients
+            # A sample is assigned to a patient
+            ars = context.getAnalysisRequests()
+            for ar in ars:
+                patient = ar.getField('Patient').get(ar)
+                if patient is not None:
+                    return patient
+        return None

--- a/bika/health/browser/analysisrequest/configure.zcml
+++ b/bika/health/browser/analysisrequest/configure.zcml
@@ -20,4 +20,13 @@
       layer="bika.lims.interfaces.IBikaLIMS"
     />
 
+    <!-- Hooks to set default values to AR Add fields -->
+    <!-- Patient field -->
+    <adapter
+      factory="bika.health.browser.analysisrequest.add.GetDefaultFieldPatient"
+      for="*"
+      provides="bika.lims.interfaces.IGetDefaultFieldValueARAddHook"
+      name="Patient_default_value_hook"
+    />
+
 </configure>

--- a/bika/health/static/js/bika.health.analysisrequest.add.js
+++ b/bika/health/static/js/bika.health.analysisrequest.add.js
@@ -72,12 +72,18 @@ function HealthAnalysisRequestAddView() {
                 colposition = get_arnum(this);
                 if (colposition == undefined){
                     // we are on the specific health template
-                    colposition = 0}
+                    colposition = 0;}
                 uid = $("#" + this.id + "_uid").val();
                 loadPatientFromSample(uid, colposition);
                 checkClientContacts();
             });
-
+            var field_val;
+            $.each($('input[id^="Sample-"]'), function( index, value ) {
+                field_val = $("#" + this.id + "_uid").val();
+                if (field_val != '' && field_val != undefined){
+                    $(this).trigger('selected');
+                }
+            });
             // The Batch, Patient and PatientCID combos must only show the
             // records from the current client
             filterComboSearches();
@@ -110,7 +116,7 @@ function HealthAnalysisRequestAddView() {
                 },
                 dataType: "json",
                 success: function (data, textStatus, $XHR) {
-                    if (data['PatientUID'] != '') {
+                    if (data.PatientID != '' && data.PatientID != undefined) {
                         $("#Patient-" + colposition)
                             .val(data['PatientFullname'])
                             .attr('uid', data['PatientUID'])
@@ -366,7 +372,7 @@ function HealthAnalysisRequestAddView() {
                 dataType: "json",
                 async: false,
                 success: function (data, textStatus, $XHR) {
-                    if (data['PatientID'] != '') {
+                    if (data.PatientID != '' && data.PatientID != undefined) {
                         fillPatientData(col, data);
                     } else {
                         resetPatientData(col);
@@ -406,12 +412,12 @@ function HealthAnalysisRequestAddView() {
         $("#Patient-" + col).val('');
         $("#Patient-" + col).attr('uid', '');
         $("#Patient-" + col + "_uid").val('');
-        $("#Patient-" + col).combogrid("option", "disabled", false);
+//        $("#Patient-" + col).combogrid("option", "disabled", false);
 
         $("#ClientPatientID-" + col).val('');
         $("#ClientPatientID-" + col).attr('uid', '');
         $("#ClientPatientID-" + col + "_uid").val('');
-        $("#ClientPatientID-" + col).combogrid("option", "disabled", false);
+//        $("#ClientPatientID-" + col).combogrid("option", "disabled", false);
 
         frombatch = window.location.href.search('/batches/') >= 0;
         frompatient = document.referrer.search('/patients/') >= 0;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR goes together with: https://github.com/senaite/senaite.core/pull/594

This PR adds a the class `GetDefaultFieldPatient` that adapts `IGetDefaultFieldValueARAddHook`.

If this adapter is called, it will return the default value for `Patient` field in that context. 

It also adds some JS code to avoid potential inconsistencies.

## Current behavior before PR

`get_default_value` method from ARAdd form was only giving default values to Analysis Request fields defined in SENAITE.CORE .

## Desired behavior after PR is merged

Depending on the context, `Patient` field will be filed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
