### PR TITLE
Changed dependency names.

### DIFF
--- a/bika/health/profiles/default/metadata.xml
+++ b/bika/health/profiles/default/metadata.xml
@@ -2,6 +2,6 @@
 <metadata>
   <version>1.1.1</version>
   <dependencies>
-    <dependency>profile-bika.lims:default</dependency>
+    <dependency>profile-senaite.core:default</dependency>
   </dependencies>
 </metadata>

--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -128,7 +128,7 @@ def setupHealthVarious(context):
     setup.runImportStepFromProfile('profile-plone.app.jquerytools:default', 'jsregistry')
 
     # Load bika.lims js always before bika.health ones.
-    setup.runImportStepFromProfile('profile-bika.lims:default', 'jsregistry')
+    setup.runImportStepFromProfile('profile-senaite.core:default', 'jsregistry')
 
     # Add patient action for client portal_type programmatically
     client = portal.portal_types.getTypeInfo("Client")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Some dependencies were being called by 'bika.lims' name

## Current behavior before PR
Fails when installing the install from scratch.

## Desired behavior after PR is merged
Senaite Health instance doesn't fail.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
