### PR TITLE
ConfigurationConflictError in "The workflow actions menu"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #45 ConfigurationConflictError in "The workflow actions menu"
 
 **Security**
 

--- a/bika/health/browser/overrides.zcml
+++ b/bika/health/browser/overrides.zcml
@@ -18,6 +18,11 @@
                 permission="zope.Public"
                 template="templates/plone-overview.pt"
             />
+            <browser:menu
+                id="plone_contentmenu_workflow"
+                title="The workflow actions menu"
+                class="bika.lims.browser.contentmenu.WorkflowMenu"
+            />
         </unconfigure>
     </configure>
 


### PR DESCRIPTION
## Current behavior before PR
Running instance fails because of `ConfigurationConflictError`.

## Desired behavior after PR is merged
Plone's default view with ID 'plone_contentmenu_workflow' is unconfigured before being overriden.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
