### PR TITLE
Redirect to Patient's ARs view after Patient creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changelog
 
 **Changed**
 
+- #48 After saving a newly created Patient the user is redirected to the Patient's Analysis Requests view instead of the Patient's edit view.
 
 **Fixed**
 

--- a/bika/health/skins/bika_health/validate_integrity.cpy
+++ b/bika/health/skins/bika_health/validate_integrity.cpy
@@ -24,6 +24,9 @@ else:
     message = _(u'Changes saved.')
     stat = 'created'
 
+    # redirect to Patient's ARs view when saving a newly created patient
+    patient_redirection = '/'.join(['/patients', context.getPatientID(), 'analysisrequests'])
+
     # Redirection after saving edition forms
     redirects = {'AetiologicAgent' : '/bika_setup/bika_aetiologicagents',
                  'BatchLabel' : '/bika_setup/bika_batchlabels',
@@ -39,7 +42,8 @@ else:
                  'InsuranceCompany':  '/bika_setup/bika_insurancecompanies',
                  'EpidemiologicalYear': '/bika_setup/bika_epidemiologicalyears',
                  'IdentifierType': '/bika_setup/bika_identifiertypes',
-                 'Symptom': '/bika_setup/bika_symptoms'}
+                 'Symptom': '/bika_setup/bika_symptoms',
+                 'Patient': patient_redirection}
 
     if context.portal_type in redirects:
         redirect = 'redirect_to:string:${portal_url}' + redirects[context.portal_type]

--- a/bika/health/skins/bika_health/validate_integrity.cpy
+++ b/bika/health/skins/bika_health/validate_integrity.cpy
@@ -25,7 +25,9 @@ else:
     stat = 'created'
 
     # redirect to Patient's ARs view when saving a newly created patient
-    patient_redirection = '/'.join(['/patients', context.getPatientID(), 'analysisrequests'])
+    patient_redirection = ''
+    if context.portal_type == 'Patient':
+        patient_redirection = '/'.join(['/patients', context.getPatientID(), 'analysisrequests'])
 
     # Redirection after saving edition forms
     redirects = {'AetiologicAgent' : '/bika_setup/bika_aetiologicagents',


### PR DESCRIPTION
Related PR: #47 

## Description of the issue/feature this PR addresses

Linked issue: #46 (This PR addresses steps 4, 5, 6 and 7).

## Current behavior before PR

After saving a newly created Patient the user was redirected to the Patient's edit view.

## Desired behavior after PR is merged

After saving a newly created Patient the user is redirected to the Patient's Analysis Requests view instead of the Patient's edit view.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
