### PR TITLE
Default publication preference for Patients in Clients vocabulary error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 **Fixed**
 
 - #45 ConfigurationConflictError in "The workflow actions menu"
+- #49 Default publication preference for Patients in Clients vocabulary error
 
 **Security**
 

--- a/bika/health/content/client.py
+++ b/bika/health/content/client.py
@@ -48,7 +48,7 @@ class ClientSchemaExtender(object):
                               "preferences' tab."))
         ),
         ExtLinesField('PatientPublicationPreferences',
-            vocabulary='bika.lims.vocabularies.CustomPubPrefVocabularyFactory',
+            vocabulary_factory='bika.lims.vocabularies.CustomPubPrefVocabularyFactory',
             schemata='Results Reports',
             widget=MultiSelectionWidget(
                 label=_("Default publication preference for Patients"),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Vocabulary items aren't displayed inside the widget.

## Current behavior before PR

![selection_006](https://user-images.githubusercontent.com/7425587/36544656-45a2cfa0-17e7-11e8-9e25-8b66109bfd65.png)

## Desired behavior after PR is merged

![selection_005](https://user-images.githubusercontent.com/7425587/36544661-47cc9b76-17e7-11e8-9946-7de5d89fc9aa.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
