### PR TITLE
Date Collected missing in reports

### DIFF
--- a/bika/health/browser/analysisrequest/templates/reports/default.pt
+++ b/bika/health/browser/analysisrequest/templates/reports/default.pt
@@ -290,7 +290,7 @@
         </tr>
         <tr>
             <td class="label" i18n:translate="">Sample Collected</td>
-            <td tal:content="python:view.ulocalized_time(ar_obj.getSamplingDate(), long_format=0)"></td>
+            <td tal:content="python:view.ulocalized_time(ar_obj.getDateSampled(), long_format=0)"></td>
         </tr>
         <tr>
             <td class="label" i18n:translate="">Sample Received</td>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The field Date Collected that appears when creating a patient report was missing its value.

## Current behavior before PR

Date Collected field value is missing (it is blank) on the reports.

## Desired behavior after PR is merged

Date Collected field is filled with the correct date.

**Notes**

The value for the field Date Collected was being retrieved from the column `getSamplingDate` instead of `getDateSampled`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html


