### PR TITLE
Date Reported missing in reports

### DIFF
--- a/bika/health/browser/analysisrequest/templates/reports/default.pt
+++ b/bika/health/browser/analysisrequest/templates/reports/default.pt
@@ -299,8 +299,8 @@
         </tr>
         <tr>
             <td class="label" i18n:translate="">Date Reported</td>
-            <td tal:content="python:view.ulocalized_time(ar_obj.getDatePublished(), long_format=1)or \
-                                    view.ulocalized_time(DateTime(), long_format=1)></td>
+            <td tal:content="python:view.ulocalized_time(ar_obj.getDatePublished(), long_format=1) or \
+                                    view.ulocalized_time(DateTime(), long_format=1)"></td>
         </tr>
     </table>
 </div>

--- a/bika/health/browser/analysisrequest/templates/reports/default.pt
+++ b/bika/health/browser/analysisrequest/templates/reports/default.pt
@@ -21,7 +21,8 @@
                         ar_obj          python:analysisrequest['obj'];
                         patient         python:view.get_patient(ar_obj);
                         batch_obj       python:ar_obj.getBatch();
-                        sample_obj      python:ar_obj.getSample();">
+                        sample_obj      python:ar_obj.getSample();
+                        DateTime        python:modules['DateTime'].DateTime">
 
 <!--
     Page Header
@@ -298,7 +299,8 @@
         </tr>
         <tr>
             <td class="label" i18n:translate="">Date Reported</td>
-            <td tal:content="python:view.ulocalized_time(ar_obj.getDatePublished(), long_format=1)"></td>
+            <td tal:content="python:view.ulocalized_time(ar_obj.getDatePublished(), long_format=1)or \
+                                    view.ulocalized_time(DateTime(), long_format=1)></td>
         </tr>
     </table>
 </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Date Reported field value is missing (it is blank) in the reports. 

## Current behavior before PR

When viewing a report, the value of the field Date Reported is missing (it is blank). In fact, the Date Reported is properly shown once the report has been published but in the report preview before publishing it is not shown since it is not set yet. 

## Desired behavior after PR is merged

Date Reported field is filled with the correct date both for published reports and for preview reports. When the report is previewed the value for Date Reported is set to be the current date.

**Notes**

The Date Reported is properly shown when viewing a published report.

However, when previewing it before publishing the field Date Reported
has a blank value before it has not been et yet. If this commit is
applied it will show the current date when the Date Reported isn't
set yet.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
