### PR TITLE
Add option and validator to make Client Patient ID unique

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #56 Option for making Client Patient IDs unique
 
 **Removed**
 

--- a/bika/health/catalog/patient_catalog.py
+++ b/bika/health/catalog/patient_catalog.py
@@ -38,6 +38,7 @@ _indexes_dict = {
     'getFullname': 'FieldIndex',
     # (values from PatientIdentifiers field)
     'getPatientIdentifiers': 'KeywordIndex',
+    'getClientPatientID': 'FieldIndex',
 }
 # Defining the columns for this catalog
 _columns_list = [

--- a/bika/health/content/bikasetup.py
+++ b/bika/health/content/bikasetup.py
@@ -124,6 +124,15 @@ class BikaSetupSchemaExtender(object):
                             "creating a case?")
                             )
                         ),
+        ExtBooleanField('ClientPatientIDUnique',
+                        schemata="ID Server",
+                        default=False,
+                        widget=BooleanWidget(
+                            label=_("Client Patient ID must be unique"),
+                            description=_("If selected, Client Patient IDs will be forced "
+                                          "to be unique")
+                        )
+                        ),
     ]
 
     def __init__(self, context):

--- a/bika/health/content/patient.py
+++ b/bika/health/content/patient.py
@@ -408,6 +408,7 @@ schema = Person.schema.copy() + Schema((
     ),
     StringField('ClientPatientID',
             searchable=1,
+            validators=('unique_client_patient_ID_validator',),
             required=1,
             widget=StringWidget(
                 label=_('Client Patient ID'),

--- a/bika/health/upgrade/v01_01_001.py
+++ b/bika/health/upgrade/v01_01_001.py
@@ -28,7 +28,6 @@ def upgrade(tool):
 
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
-    # Required to make filtering by department in worksheets work
     ut.addIndex(CATALOG_PATIENT_LISTING, 'getClientPatientID', 'FieldIndex')
     ut.refreshCatalogs()
 

--- a/bika/health/upgrade/v01_01_001.py
+++ b/bika/health/upgrade/v01_01_001.py
@@ -9,6 +9,7 @@ from bika.health import logger
 from bika.health.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
+from bika.health.catalog.patient_catalog import CATALOG_PATIENT_LISTING
 
 version = '1.1.1'
 profile = 'profile-{0}:default'.format(product)
@@ -27,7 +28,9 @@ def upgrade(tool):
 
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
-    # -------- ADD YOUR STUFF HERE --------
+    # Required to make filtering by department in worksheets work
+    ut.addIndex(CATALOG_PATIENT_LISTING, 'getClientPatientID', 'FieldIndex')
+    ut.refreshCatalogs()
 
     logger.info("{0} upgraded to version {1}".format(product, version))
 

--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -61,15 +61,15 @@ class UniqueClientPatientIDValidator:
         patients = api.search(query, CATALOG_PATIENT_LISTING)
         # If the search by Client Patient ID (value) returns
         # one or more values then Client Patient ID is not unique
-        if patients:
-            instance = kwargs['instance']
-            trans = getToolByName(instance, 'translation_service').translate
-            msg = _(
-                "Validation failed: '${value}' is not unique",
-                mapping={
-                    'value': safe_unicode(value)
-                })
-            return to_utf8(trans(msg))
-        return True
+        if not patients:
+            return True
+        instance = kwargs['instance']
+        trans = getToolByName(instance, 'translation_service').translate
+        msg = _(
+            "Validation failed: '${value}' is not unique",
+            mapping={
+                'value': safe_unicode(value)
+            })
+        return to_utf8(trans(msg))
 
 validation.register(UniqueClientPatientIDValidator())

--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -57,9 +57,8 @@ class UniqueClientPatientIDValidator:
         # avoid the catalog query if the option is not selected
         if not api.get_bika_setup().ClientPatientIDUnique:
             return True
-
-        patient_catalog = api.get_tool(CATALOG_PATIENT_LISTING)
-        patients = patient_catalog(getClientPatientID=value)
+        query = dict(getClientPatientID=value)
+        patients = api.search(query, CATALOG_PATIENT_LISTING)
         # If the search by Client Patient ID (value) returns
         # one or more values then Client Patient ID is not unique
         if patients:

--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -57,20 +57,20 @@ class UniqueClientPatientIDValidator:
         # avoid the catalog query if the option is not selected
         if not api.get_bika_setup().ClientPatientIDUnique:
             return True
-        else:
-            patient_catalog = api.get_tool(CATALOG_PATIENT_LISTING)
-            patients = patient_catalog(getClientPatientID=value)
-            # If the search by Client Patient ID (value) returns
-            # one or more values then Client Patient ID is not unique
-            if patients:
-                instance = kwargs['instance']
-                trans = getToolByName(instance, 'translation_service').translate
-                msg = _(
-                    "Validation failed: '${value}' is not unique",
-                    mapping={
-                        'value': safe_unicode(value)
-                    })
-                return to_utf8(trans(msg))
-            return True
+
+        patient_catalog = api.get_tool(CATALOG_PATIENT_LISTING)
+        patients = patient_catalog(getClientPatientID=value)
+        # If the search by Client Patient ID (value) returns
+        # one or more values then Client Patient ID is not unique
+        if patients:
+            instance = kwargs['instance']
+            trans = getToolByName(instance, 'translation_service').translate
+            msg = _(
+                "Validation failed: '${value}' is not unique",
+                mapping={
+                    'value': safe_unicode(value)
+                })
+            return to_utf8(trans(msg))
+        return True
 
 validation.register(UniqueClientPatientIDValidator())

--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -39,6 +39,7 @@ class Date_Format_Validator:
             return to_utf8(trans(msg))
         return True
 
+
 validation.register(Date_Format_Validator())
 
 
@@ -71,5 +72,6 @@ class UniqueClientPatientIDValidator:
                 'value': safe_unicode(value)
             })
         return to_utf8(trans(msg))
+
 
 validation.register(UniqueClientPatientIDValidator())

--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -60,6 +60,8 @@ class UniqueClientPatientIDValidator:
         else:
             patient_catalog = api.get_tool(CATALOG_PATIENT_LISTING)
             patients = patient_catalog(getClientPatientID=value)
+            # If the search by Client Patient ID (value) returns
+            # one or more values then it is not unique
             if patients:
                 instance = kwargs['instance']
                 trans = getToolByName(instance, 'translation_service').translate

--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -61,7 +61,7 @@ class UniqueClientPatientIDValidator:
             patient_catalog = api.get_tool(CATALOG_PATIENT_LISTING)
             patients = patient_catalog(getClientPatientID=value)
             # If the search by Client Patient ID (value) returns
-            # one or more values then it is not unique
+            # one or more values then Client Patient ID is not unique
             if patients:
                 instance = kwargs['instance']
                 trans = getToolByName(instance, 'translation_service').translate

--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -38,3 +38,26 @@ class Date_Format_Validator:
         return True
 
 validation.register(Date_Format_Validator())
+
+
+class UniqueClientPatientIDValidator:
+    """
+    Checks if the client patient ID is unique. It does
+    so only if the checkbox 'Client Patient ID must be
+    unique' is selected . This checkbox can be found in
+    Bika Setup under Id server tab
+    """
+
+    implements(IValidator)
+    name = "unique_client_patient_ID_validator"
+
+    def __call__(self, value, *args, **kwargs):
+        # first check if the unique client patient id
+        # option is selected
+
+        # if not, return always true
+
+        # else perform the validation
+        return False
+
+validation.register(Date_Format_Validator())

--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -60,4 +60,4 @@ class UniqueClientPatientIDValidator:
         # else perform the validation
         return False
 
-validation.register(Date_Format_Validator())
+validation.register(UniqueClientPatientIDValidator())


### PR DESCRIPTION
**Note**: For this functionality to be effective `senaite.health` has to be upgraded to v.1.1.1 (since we check Client Patient ID uniqueness via the index `getClientPatientID` and this index has to be added to the patients catalog).

## Description of the issue/feature this PR addresses

There is no option to force Client Patient IDs to be unique.

## Current behavior before PR

Client Patients ID couldn't be forced to be unique.

## Desired behavior after PR is merged

There is a new option under Bika Setup -> ID Server that allows to specify if Client Patient IDs must be unique. Note that,  **by default, the option is not selected**.

If the option is selected then Client Patient IDs will be forced to be unique over the whole database. If a repeated Client Patient ID is entered an error will be raised pointing it out.

![seleccio_003](https://user-images.githubusercontent.com/9968427/37199668-9d06b986-2382-11e8-909a-6dbe6d08ff6d.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
