### PR TITLE
Fix unique Client Patient ID validation

### DIFF
--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -67,7 +67,7 @@ class UniqueClientPatientIDValidator:
             return True
         # If there is only one patient with this Client Patient ID
         # and it is the patient being edited then it also valid
-        elif len(patients) == 1 and patients[0].getObject() == instance:
+        elif len(patients) == 1 and patients[0].UID == instance.UID():
             return True
         trans = getToolByName(instance, 'translation_service').translate
         msg = _(

--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -60,11 +60,15 @@ class UniqueClientPatientIDValidator:
             return True
         query = dict(getClientPatientID=value)
         patients = api.search(query, CATALOG_PATIENT_LISTING)
-        # If the search by Client Patient ID (value) returns
-        # one or more values then Client Patient ID is not unique
+        instance = kwargs.get('instance')
+        # If there are no patients with this Client Patient ID
+        # then it is valid
         if not patients:
             return True
-        instance = kwargs['instance']
+        # If there is only one patient with this Client Patient ID
+        # and it is the patient being edited then it also valid
+        elif len(patients) == 1 and patients[0].getObject() == instance:
+            return True
         trans = getToolByName(instance, 'translation_service').translate
         msg = _(
             "Validation failed: '${value}' is not unique",

--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -67,7 +67,7 @@ class UniqueClientPatientIDValidator:
             return True
         # If there is only one patient with this Client Patient ID
         # and it is the patient being edited then it also valid
-        elif len(patients) == 1 and patients[0].UID == instance.UID():
+        if len(patients) == 1 and api.get_uid(patients[0]) == api.get_uid(instance):
             return True
         trans = getToolByName(instance, 'translation_service').translate
         msg = _(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #60 

The validation that checks if a Client Patient ID is unique is not working properly. 

## Current behavior before PR

If _Client Patient ID must be unique_ is checked (under Site Setup -> Bika Setup -> Id Server) a validation error is **always** raised in the Edit/Create patient form stating that the Client Patient ID is not unique.

## Desired behavior after PR is merged

If _Client Patient ID must be unique_ is checked then the field is validated properly. This means that errors are only raised when there is a repeated Client Patient ID and Patients can be created and edited properly.

The validator was assuming that the Client Patient ID was unique if a query to the patients catalog by Client Patient ID returned 0 results. However it should also be checked if, when there is only one result, that one result is the current patient being edited.  

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
