### PR TITLE
Show doctor in Analysis Requests listings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 **Added**
 
 - #56 Option for making Client Patient IDs unique
+- #63 Display Doctor column in Analysis Requests listings
 
 **Removed**
 

--- a/bika/health/browser/analysisrequests/view.py
+++ b/bika/health/browser/analysisrequests/view.py
@@ -60,13 +60,13 @@ class AnalysisRequestsView(BaseView):
         patient = self.patient_catalog(UID=obj.getPatientUID)
         if patient:
             item['getPatientID'] = patient[0].getId
-            item['replace']['getPatientID'] = "<a href='%s'>%s</a>" % \
+            item['replace']['getPatientID'] = "<a href='%s/analysisrequests'>%s</a>" % \
                 (patient[0].getURL(), patient[0].getId)
             item['getClientPatientID'] = patient[0].getClientPatientID
-            item['replace']['getClientPatientID'] = "<a href='%s'>%s</a>" % \
+            item['replace']['getClientPatientID'] = "<a href='%s/analysisrequests'>%s</a>" % \
                 (patient[0].getURL(), patient[0].getClientPatientID)
             item['getPatient'] = patient[0].Title
-            item['replace']['getPatient'] = "<a href='%s'>%s</a>" % \
+            item['replace']['getPatient'] = "<a href='%s/analysisrequests'>%s</a>" % \
                 (patient[0].getURL(), patient[0].Title)
         doctor_uid = obj.getDoctorUID
         if doctor_uid:

--- a/bika/health/browser/analysisrequests/view.py
+++ b/bika/health/browser/analysisrequests/view.py
@@ -5,6 +5,7 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+from bika.lims import api
 from bika.lims.browser.analysisrequest import AnalysisRequestsView as BaseView
 from bika.health import bikaMessageFactory as _
 from Products.CMFCore.utils import getToolByName
@@ -24,6 +25,8 @@ class AnalysisRequestsView(BaseView):
             'sortable': False, }
         self.columns['getPatient'] = {
             'title': _('Patient'), }
+        self.columns['getDoctor'] = {
+            'title': _('Doctor'), }
 
     def folderitems(self, full_objects=False):
         pm = getToolByName(self.context, "portal_membership")
@@ -44,6 +47,7 @@ class AnalysisRequestsView(BaseView):
                 rs['columns'].insert(i, 'getClientPatientID')
                 rs['columns'].insert(i, 'getPatientID')
                 rs['columns'].insert(i, 'getPatient')
+                rs['columns'].insert(i, 'getDoctor')
         # Setting ip the patient catalog to be used in folderitem()
         self.patient_catalog = getToolByName(
             self.context, CATALOG_PATIENT_LISTING)
@@ -64,4 +68,12 @@ class AnalysisRequestsView(BaseView):
             item['getPatient'] = patient[0].Title
             item['replace']['getPatient'] = "<a href='%s'>%s</a>" % \
                 (patient[0].getURL(), patient[0].Title)
+        doctor_uid = obj.getDoctorUID
+        if doctor_uid:
+            doctor = api.get_object_by_uid(doctor_uid)
+            if doctor:
+                item['getDoctor'] = doctor.Title()
+                item['replace']['getDoctor'] = "<a href='%s/analysisrequests'>%s</a>" % \
+                                                (api.get_url(doctor),
+                                                 doctor.Title())
         return item

--- a/bika/health/browser/analysisrequests/view.py
+++ b/bika/health/browser/analysisrequests/view.py
@@ -38,10 +38,10 @@ class AnalysisRequestsView(BaseView):
         if 'Manager' not in roles \
             and 'LabManager' not in roles \
                 and 'LabClerk' not in roles:
-            del self.columns['getPatientID']
-            del self.columns['getClientPatientID']
-            del self.columns['getPatient']
-            del self.columns['getDoctor']
+            self.remove_column('getPatientID')
+            self.remove_column('getClientPatientID')
+            self.remove_column('getPatient')
+            self.remove_column('getDoctor')
         # Otherwise show the columns in the list
         else:
             for rs in self.review_states:

--- a/bika/health/browser/analysisrequests/view.py
+++ b/bika/health/browser/analysisrequests/view.py
@@ -41,6 +41,7 @@ class AnalysisRequestsView(BaseView):
             del self.columns['getPatientID']
             del self.columns['getClientPatientID']
             del self.columns['getPatient']
+            del self.columns['getDoctor']
         # Otherwise show the columns in the list
         else:
             for rs in self.review_states:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Displays the column Doctor in Analysis Requests listings. It also improves the performance of the lists rendering both by making use of `plone.memoize` and querying for brains (doctor + patient) only.

## Current behavior before PR

Doctor column is not displayed in Analysis Requests listings

## Desired behavior after PR is merged

Doctor column is displayed with linkable items in Analysis Requests listings

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
