### PR TITLE
Samples list not filtered in Doctor Samples view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #64 Samples not filtered in Doctor's samples view
 - #45 ConfigurationConflictError in "The workflow actions menu"
 - #49 Default publication preference for Patients in Clients vocabulary error
 

--- a/bika/health/browser/doctor/samples.py
+++ b/bika/health/browser/doctor/samples.py
@@ -19,6 +19,9 @@ class SamplesView(BaseView):
         return super(SamplesView, self).__call__()
 
     def get_sample_uids(self):
+        """Returns the sample UIDs for which the current Doctor has at least
+        one Analysis Request assigned."""
         query = dict(getDoctorUID=api.get_uid(self.context))
         ars = api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING)
-        return map(lambda brain: brain.getSampleUID, ars) or list()
+        uids = map(lambda brain: brain.getSampleUID, ars) or list()
+        return list(set(uids))

--- a/bika/health/browser/doctor/samples.py
+++ b/bika/health/browser/doctor/samples.py
@@ -5,25 +5,20 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from bika.health.browser.samples.folder_view import SamplesView
-from Products.CMFCore.utils import getToolByName
+from bika.lims import api
+from bika.health.browser.samples.folder_view import SamplesView as BaseView
+from bika.lims.catalog.analysisrequest_catalog import \
+    CATALOG_ANALYSIS_REQUEST_LISTING
 
 
-class SamplesView(SamplesView):
+class SamplesView(BaseView):
 
-    def __init__(self, context, request):
-        super(SamplesView, self).__init__(context, request)
-        self.contentFilter['Doctor'] = self.context.UID()
+    def __call__(self):
+        self.remove_column('getDoctor')
+        self.contentFilter['UID'] = self.get_sample_uids()
+        return super(SamplesView, self).__call__()
 
-    def contentsMethod(self, contentFilter):
-        tool = getToolByName(self.context, self.catalog)
-        state = [x for x in self.review_states if x['id'] == self.review_state['id']][0]
-        for k, v in state['contentFilter'].items():
-            self.contentFilter[k] = v
-        tool_samples = tool(contentFilter)
-        samples = {}
-        for sample in (p.getObject() for p in tool_samples):
-            for ar in sample.getAnalysisRequests():
-                if ar['Doctor'] == self.context.UID():
-                    samples[sample.getId()] = sample
-        return samples.values()
+    def get_sample_uids(self):
+        query = dict(getDoctorUID=api.get_uid(self.context))
+        ars = api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING)
+        return map(lambda brain: brain.getSampleUID, ars) or list()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

All Samples are listed in Doctor's Samples view. Note that a Doctor can be assigned to zero or more Analysis Requests, but one Sample can contain more than one Analysis Request.

## Current behavior before PR

All Samples are listed in Doctor's Samples view

## Desired behavior after PR is merged

Only the Samples for which at least one Analysis Request the current Doctor is assigned to are displayed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
