### PR TITLE
Fix api import

### DIFF
--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -13,7 +13,7 @@ from zope.interface import implements
 from Products.validation import validation
 from Products.validation.interfaces.IValidator import IValidator
 from datetime import datetime
-from senaite import api
+from bika.lims import api
 from bika.health.catalog.patient_catalog import CATALOG_PATIENT_LISTING
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The api should be imported from `bika.lims` and not `senaite`

## Current behavior before PR

The `api` was being imported from `senaite`

## Desired behavior after PR is merged

The `api` is imported from `bika.lims`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
