### PR TITLE
Index and Metadata optimizations for AR Listing View

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changelog
 
 **Changed**
 
+- #70 Index and Metadata optimizations for AR Listing View
 
 **Removed**
 

--- a/bika/health/__init__.py
+++ b/bika/health/__init__.py
@@ -18,7 +18,7 @@ from bika.health.permissions import *
 
 from AccessControl import ModuleSecurityInfo, allow_module
 from Products.Archetypes.atapi import process_types, listTypes
-from Products.CMFCore import utils
+from Products.CMFCore import utils as plone_utils
 from Products.CMFCore.DirectoryView import registerDirectory
 from Products.CMFCore.utils import ContentInit, ToolInit, getToolByName
 from Products.CMFPlone import PloneMessageFactory
@@ -83,7 +83,7 @@ def initialize(context):
     for atype, constructor in allTypes:
         kind = "%s: Add %s" % (config.PROJECTNAME, atype.portal_type)
         perm = ADD_CONTENT_PERMISSIONS.get(atype.portal_type, ADD_CONTENT_PERMISSION)
-        utils.ContentInit(kind,
+        plone_utils.ContentInit(kind,
                           content_types      = (atype,),
                           permission         = perm,
                           extra_constructors = (constructor,),

--- a/bika/health/browser/analysisrequests/view.py
+++ b/bika/health/browser/analysisrequests/view.py
@@ -20,14 +20,21 @@ class AnalysisRequestsView(BaseView):
         self.columns['BatchID']['title'] = _('Case ID')
         # Add Client Patient fields
         self.columns['getPatientID'] = {
-            'title': _('Patient ID'), }
+            'title': _('Patient ID'),
+            'index': _('getPatientId'),
+        }
         self.columns['getClientPatientID'] = {
             'title': _("Client PID"),
-            'sortable': False, }
+            'sortable': False,
+        }
         self.columns['getPatient'] = {
-            'title': _('Patient'), }
+            'title': _('Patient'),
+            'index': _('getPatientTitle'),
+        }
         self.columns['getDoctor'] = {
-            'title': _('Doctor'), }
+            'title': _('Doctor'),
+            'index': _('getDoctorTitle'),
+        }
 
     def folderitems(self, full_objects=False):
         pm = getToolByName(self.context, "portal_membership")
@@ -66,20 +73,16 @@ class AnalysisRequestsView(BaseView):
     def folderitem(self, obj, item, index):
         item = super(AnalysisRequestsView, self)\
             .folderitem(obj, item, index)
-        patient = self.get_brain(obj.getPatientUID, CATALOG_PATIENT_LISTING)
-        if patient:
-            cpid = patient.getClientPatientID
-            url = '%s/analysisrequests' % api.get_url(patient)
-            item['getPatientID'] = patient.getId
-            item['getClientPatientID'] = patient.getClientPatientID
-            item['getPatient'] = patient.Title
-            item['replace']['getPatientID'] = get_link(url, patient.getId)
-            item['replace']['getClientPatientID'] = get_link(url, cpid)
-            item['replace']['getPatient'] = get_link(url, patient.Title)
 
-        doctor = self.get_brain(obj.getDoctorUID, "portal_catalog")
-        if doctor:
-            url = '%s/analysisrequests' % api.get_url(doctor)
-            item['getDoctor'] = doctor.Title
-            item['replace']['getDoctor'] = get_link(url, doctor.Title)
+        item['getPatientID'] = obj.getPatientId
+        item['getPatient'] = obj.getPatientTitle
+        item['getClientPatientID'] = obj.getClientPatientID
+        url = '{}/analysisrequests'.format(obj.getPatientURL)
+        item['replace']['getPatient'] = get_link(url, obj.getPatientTitle)
+        item['replace']['getPatientID'] = get_link(url, obj.getPatientId)
+        item['replace']['getClientPatientID'] = get_link(url, obj.getClientPatientID)
+
+        item['getDoctor'] = obj.getDoctorTitle
+        url = '{}/analysisrequests'.format(obj.getDoctorTitle)
+        item['replace']['getDoctor'] = get_link(url, obj.getDoctorTitle)
         return item

--- a/bika/health/browser/analysisrequests/view.py
+++ b/bika/health/browser/analysisrequests/view.py
@@ -83,6 +83,7 @@ class AnalysisRequestsView(BaseView):
         item['replace']['getClientPatientID'] = get_link(url, obj.getClientPatientID)
 
         item['getDoctor'] = obj.getDoctorTitle
-        url = '{}/analysisrequests'.format(obj.getDoctorTitle)
-        item['replace']['getDoctor'] = get_link(url, obj.getDoctorTitle)
+        if obj.getDoctorURL:
+            url = '{}/analysisrequests'.format(obj.getDoctorURL)
+            item['replace']['getDoctor'] = get_link(url, obj.getDoctorTitle)
         return item

--- a/bika/health/browser/analysisrequests/view.py
+++ b/bika/health/browser/analysisrequests/view.py
@@ -74,12 +74,12 @@ class AnalysisRequestsView(BaseView):
         item = super(AnalysisRequestsView, self)\
             .folderitem(obj, item, index)
 
-        item['getPatientID'] = obj.getPatientId
+        item['getPatientID'] = obj.getPatientID
         item['getPatient'] = obj.getPatientTitle
         item['getClientPatientID'] = obj.getClientPatientID
         url = '{}/analysisrequests'.format(obj.getPatientURL)
         item['replace']['getPatient'] = get_link(url, obj.getPatientTitle)
-        item['replace']['getPatientID'] = get_link(url, obj.getPatientId)
+        item['replace']['getPatientID'] = get_link(url, obj.getPatientID)
         item['replace']['getClientPatientID'] = get_link(url, obj.getClientPatientID)
 
         item['getDoctor'] = obj.getDoctorTitle

--- a/bika/health/browser/analysisrequests/view.py
+++ b/bika/health/browser/analysisrequests/view.py
@@ -21,19 +21,16 @@ class AnalysisRequestsView(BaseView):
         # Add Client Patient fields
         self.columns['getPatientID'] = {
             'title': _('Patient ID'),
-            'index': _('getPatientId'),
         }
         self.columns['getClientPatientID'] = {
             'title': _("Client PID"),
             'sortable': False,
         }
-        self.columns['getPatient'] = {
+        self.columns['getPatientTitle'] = {
             'title': _('Patient'),
-            'index': _('getPatientTitle'),
         }
-        self.columns['getDoctor'] = {
+        self.columns['getDoctorTitle'] = {
             'title': _('Doctor'),
-            'index': _('getDoctorTitle'),
         }
 
     def folderitems(self, full_objects=False):
@@ -47,16 +44,16 @@ class AnalysisRequestsView(BaseView):
                 and 'LabClerk' not in roles:
             self.remove_column('getPatientID')
             self.remove_column('getClientPatientID')
-            self.remove_column('getPatient')
-            self.remove_column('getDoctor')
+            self.remove_column('getPatientTitle')
+            self.remove_column('getDoctorTitle')
         # Otherwise show the columns in the list
         else:
             for rs in self.review_states:
                 i = rs['columns'].index('BatchID') + 1
                 rs['columns'].insert(i, 'getClientPatientID')
                 rs['columns'].insert(i, 'getPatientID')
-                rs['columns'].insert(i, 'getPatient')
-                rs['columns'].insert(i, 'getDoctor')
+                rs['columns'].insert(i, 'getPatientTitle')
+                rs['columns'].insert(i, 'getDoctorTitle')
         return super(AnalysisRequestsView, self).folderitems(
             full_objects=False, classic=False)
 
@@ -75,15 +72,15 @@ class AnalysisRequestsView(BaseView):
             .folderitem(obj, item, index)
 
         item['getPatientID'] = obj.getPatientID
-        item['getPatient'] = obj.getPatientTitle
+        item['getPatientTitle'] = obj.getPatientTitle
         item['getClientPatientID'] = obj.getClientPatientID
         url = '{}/analysisrequests'.format(obj.getPatientURL)
-        item['replace']['getPatient'] = get_link(url, obj.getPatientTitle)
+        item['replace']['getPatientTitle'] = get_link(url, obj.getPatientTitle)
         item['replace']['getPatientID'] = get_link(url, obj.getPatientID)
         item['replace']['getClientPatientID'] = get_link(url, obj.getClientPatientID)
 
-        item['getDoctor'] = obj.getDoctorTitle
+        item['getDoctorTitle'] = obj.getDoctorTitle
         if obj.getDoctorURL:
             url = '{}/analysisrequests'.format(obj.getDoctorURL)
-            item['replace']['getDoctor'] = get_link(url, obj.getDoctorTitle)
+            item['replace']['getDoctorTitle'] = get_link(url, obj.getDoctorTitle)
         return item

--- a/bika/health/catalog/analysisrequest_catalog.py
+++ b/bika/health/catalog/analysisrequest_catalog.py
@@ -19,8 +19,14 @@ analysisrequest_catalog_definition = {
                 'getPatientID': 'FieldIndex',
             },
             'columns': [
+                'getClientPatientID',
+                'getDoctorTitle',
                 'getDoctorUID',
+                'getDoctorURL',
+                'getPatientID',
+                'getPatientTitle',
                 'getPatientUID',
+                'getPatientURL',
             ]
         }
     }

--- a/bika/health/catalog/analysisrequest_catalog.py
+++ b/bika/health/catalog/analysisrequest_catalog.py
@@ -14,8 +14,10 @@ analysisrequest_catalog_definition = {
             'indexes': {
                 'getDoctorUID': 'FieldIndex',
                 'getPatientUID': 'FieldIndex',
-                # To sort columns
-                'getPatient': 'FieldIndex',
+
+                # Indexes to sort in listing view
+                'getDoctorTitle': 'FieldIndex',
+                'getPatientTitle': 'FieldIndex',
                 'getPatientID': 'FieldIndex',
             },
             'columns': [

--- a/bika/health/catalog/indexers/__init__.py
+++ b/bika/health/catalog/indexers/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE
+#
+# Copyright 2018 by it's authors.
+# Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.

--- a/bika/health/catalog/indexers/analysisrequest.py
+++ b/bika/health/catalog/indexers/analysisrequest.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE
+#
+# Copyright 2018 by it's authors.
+# Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
+
+from bika.lims import api
+from bika.lims import logger
+from bika.lims.interfaces import IAnalysisRequest
+from plone.indexer import indexer
+from bika.lims.interfaces import IBikaCatalogAnalysisRequestListing
+
+
+@indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
+def listing_searchable_text(instance):
+    """ Indexes values of desired fields for searches in listing view. All the
+    field names added to 'plain_text_fields' will be available to search by
+    wildcards.
+    Please choose the searchable fields carefully and add only fields that
+    can be useful to search by. For example, there is no need to add 'SampleId'
+    since 'getId' of AR already contains that value. Nor 'ClientTitle' because
+    AR's are/can be filtered by client in Clients' 'AR Listing View'
+    :return: values of the fields defined as a string
+    """
+    entries = []
+    plain_text_fields = ('getId', 'getContactFullName', 'getSampleTypeTitle',
+                         'getSamplePointTitle')
+
+    # Concatenate plain text fields as they are
+    for field_name in plain_text_fields:
+        try:
+            value = api.safe_getattr(instance, field_name)
+        except:
+            logger.error("{} has no attribute called '{}' ".format(
+                            repr(instance), field_name))
+            continue
+        entries.append(value)
+
+    # Getter of senaite.health extension fields are not created. That's why
+    # we are adding them manually
+    patient_field = instance.getField('Patient', '')
+    patient = patient_field.get(instance) if patient_field else None
+    if patient:
+        entries.extend((patient.getId(), patient.Title()))
+
+    doctor_field = instance.getField('Doctor', '')
+    doctor = doctor_field.get(instance) if doctor_field else None
+    if doctor:
+        entries.extend((doctor.getId(), doctor.Title()))
+
+    # Concatenate all strings to one text blob
+    return " ".join(entries)

--- a/bika/health/catalog/indexers/analysisrequest.py
+++ b/bika/health/catalog/indexers/analysisrequest.py
@@ -84,8 +84,12 @@ def listing_searchable_text(instance):
             logger.error("{} has no attribute called '{}' ".format(
                             repr(instance), field_name))
             continue
+
+        if not value:
+            continue
         if isinstance(value, list):
             value = " ".join(value)
+
         entries.append(value)
 
     # Getters of senaite.health extension fields are not created. That's why

--- a/bika/health/catalog/indexers/analysisrequest.py
+++ b/bika/health/catalog/indexers/analysisrequest.py
@@ -19,46 +19,46 @@ from bika.lims.interfaces import IBikaCatalogAnalysisRequestListing
 # getter is created so we need to create indexes in that way.
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getPatientUID(instance):
-    return get_attr_from_field(instance, 'Patient', 'UID')
+    return get_attr_from_field(instance, 'Patient', 'UID', '')
 
 
 # We use this index to sort columns and filter lists
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getPatientTitle(instance):
-    return get_attr_from_field(instance, 'Patient', 'Title')
+    return get_attr_from_field(instance, 'Patient', 'Title', '')
 
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getPatientID(instance):
-    return get_attr_from_field(instance, 'Patient', 'Id')
+    return get_attr_from_field(instance, 'Patient', 'getId', '')
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getPatientURL(instance):
-    item = get_obj_from_field(instance, 'Patient')
-    return api.get_url(item) or ''
+    item = get_obj_from_field(instance, 'Patient', None)
+    return item and api.get_url(item) or ''
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getClientPatientID(instance):
-    return get_attr_from_field(instance, 'Patient', 'ClientPatientID')
+    return get_attr_from_field(instance, 'Patient', 'ClientPatientID', '')
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getDoctorUID(instance):
-    return get_attr_from_field(instance, 'Doctor', 'UID')
+    return get_attr_from_field(instance, 'Doctor', 'UID', '')
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getDoctorTitle(instance):
-    return get_attr_from_field(instance, 'Doctor', 'Title')
+    return get_attr_from_field(instance, 'Doctor', 'Title', '')
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getDoctorURL(instance):
-    item = get_obj_from_field(instance, 'Doctor')
-    return api.get_url(item) or ''
+    item = get_obj_from_field(instance, 'Doctor', None)
+    return item and api.get_url(item) or ''
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)

--- a/bika/health/catalog/indexers/analysisrequest.py
+++ b/bika/health/catalog/indexers/analysisrequest.py
@@ -5,89 +5,60 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+from plone.indexer import indexer
+
+from bika.health.utils import get_obj_from_field, get_attr_from_field
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.interfaces import IAnalysisRequest
-from plone.indexer import indexer
-from bika.lims.interfaces import IBikaCatalog
 from bika.lims.interfaces import IBikaCatalogAnalysisRequestListing
 
 
 # Defining the indexes for this extension. Since this is an extension, no
 # getter is created so we need to create indexes in that way.
-# TODO-catalog: delete this index
-@indexer(IAnalysisRequest, IBikaCatalog)
-def getPatientUID(instance):
-    field = instance.getField('Patient', '')
-    item = field.get(instance) if field else None
-    value = item and item.UID() or ''
-    return value
-
-
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getPatientUID(instance):
-    field = instance.getField('Patient', '')
-    item = field.get(instance) if field else None
-    value = item and item.UID() or ''
-    return value
+    return get_attr_from_field(instance, 'Patient', 'UID')
 
 
 # We use this index to sort columns and filter lists
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getPatientTitle(instance):
-    field = instance.getField('Patient', '')
-    item = field.get(instance) if field else None
-    value = item and item.Title() or ''
-    return value
+    return get_attr_from_field(instance, 'Patient', 'Title')
+
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getPatientID(instance):
-    field = instance.getField('Patient', '')
-    item = field.get(instance) if field else None
-    value = item and item.getId() or ''
-    return value
+    return get_attr_from_field(instance, 'Patient', 'Id')
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getPatientURL(instance):
-    field = instance.getField('Patient', '')
-    item = field.get(instance) if field else None
-    value = item and api.get_url(item) or ''
-    return value
+    item = get_obj_from_field(instance, 'Patient')
+    return api.get_url(item) or ''
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getClientPatientID(instance):
-    field = instance.getField('Patient', '')
-    item = field.get(instance) if field else None
-    value = item and item.getClientPatientID() or ''
-    return value
+    return get_attr_from_field(instance, 'Patient', 'ClientPatientID')
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getDoctorUID(instance):
-    field = instance.getField('Doctor', '')
-    item = field.get(instance) if field else None
-    value = item and item.UID() or ''
-    return value
+    return get_attr_from_field(instance, 'Doctor', 'UID')
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getDoctorTitle(instance):
-    field = instance.getField('Doctor', '')
-    item = field.get(instance) if field else None
-    value = item and item.Title() or ''
-    return value
+    return get_attr_from_field(instance, 'Doctor', 'Title')
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getDoctorURL(instance):
-    field = instance.getField('Doctor', '')
-    item = field.get(instance) if field else None
-    value = item and api.get_url(item) or ''
-    return value
+    item = get_obj_from_field(instance, 'Doctor')
+    return api.get_url(item) or ''
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)

--- a/bika/health/catalog/indexers/analysisrequest.py
+++ b/bika/health/catalog/indexers/analysisrequest.py
@@ -9,10 +9,56 @@ from bika.lims import api
 from bika.lims import logger
 from bika.lims.interfaces import IAnalysisRequest
 from plone.indexer import indexer
+from bika.lims.interfaces import IBikaCatalog
 from bika.lims.interfaces import IBikaCatalogAnalysisRequestListing
 
 
+# Defining the indexes for this extension. Since this is an extension, no
+# getter is created so we need to create indexes in that way.
+# TODO-catalog: delete this index
+@indexer(IAnalysisRequest, IBikaCatalog)
+def getPatientUID(instance):
+    field = instance.getField('Patient', '')
+    item = field.get(instance) if field else None
+    value = item and item.UID() or ''
+    return value
+
+
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
+def getPatientUID(instance):
+    field = instance.getField('Patient', '')
+    item = field.get(instance) if field else None
+    value = item and item.UID() or ''
+    return value
+
+
+@indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
+def getDoctorUID(instance):
+    field = instance.getField('Doctor', '')
+    item = field.get(instance) if field else None
+    value = item and item.UID() or ''
+    return value
+
+
+# We use this index to sort columns and filter lists
+@indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
+def getPatient(instance):
+    field = instance.getField('Patient', '')
+    item = field.get(instance) if field else None
+    value = item and item.Title() or ''
+    return value
+
+
+# We use this index to sort columns and filter lists
+@indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
+def getPatientID(instance):
+    field = instance.getField('Patient', '')
+    item = field.get(instance) if field else None
+    value = item and item.getId() or ''
+    return value
+
+
+@indexer(IAnalysisRequest)
 def listing_searchable_text(instance):
     """ Indexes values of desired fields for searches in listing view. All the
     field names added to 'plain_text_fields' will be available to search by
@@ -25,7 +71,10 @@ def listing_searchable_text(instance):
     """
     entries = []
     plain_text_fields = ('getId', 'getContactFullName', 'getSampleTypeTitle',
-                         'getSamplePointTitle')
+                         'getSamplePointTitle', 'getCreatorFullName',
+                         'getProfilesTitle', 'getStorageLocationTitle',
+                         'getClientOrderNumber', 'getClientReference',
+                         'getClientSampleID', 'getTemplateTitle', )
 
     # Concatenate plain text fields as they are
     for field_name in plain_text_fields:
@@ -35,9 +84,11 @@ def listing_searchable_text(instance):
             logger.error("{} has no attribute called '{}' ".format(
                             repr(instance), field_name))
             continue
+        if isinstance(value, list):
+            value = " ".join(value)
         entries.append(value)
 
-    # Getter of senaite.health extension fields are not created. That's why
+    # Getters of senaite.health extension fields are not created. That's why
     # we are adding them manually
     patient_field = instance.getField('Patient', '')
     patient = patient_field.get(instance) if patient_field else None

--- a/bika/health/catalog/indexers/configure.zcml
+++ b/bika/health/catalog/indexers/configure.zcml
@@ -1,8 +1,13 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     i18n_domain="bika">
-  <unconfigure>
-      <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text" />
-  </unconfigure>
-  <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
+
+    <unconfigure>
+        <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text" />
+    </unconfigure>
+    <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
+    <adapter factory=".analysisrequest.getPatientUID" name="getPatientUID" />
+    <adapter factory=".analysisrequest.getPatient" name="getPatient" />
+    <adapter factory=".analysisrequest.getPatientID" name="getPatientID" />
+    <adapter factory=".analysisrequest.getDoctorUID" name="getDoctorUID" />
 </configure>

--- a/bika/health/catalog/indexers/configure.zcml
+++ b/bika/health/catalog/indexers/configure.zcml
@@ -6,8 +6,13 @@
         <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text" />
     </unconfigure>
     <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
-    <adapter factory=".analysisrequest.getPatientUID" name="getPatientUID" />
-    <adapter factory=".analysisrequest.getPatient" name="getPatient" />
     <adapter factory=".analysisrequest.getPatientID" name="getPatientID" />
+    <adapter factory=".analysisrequest.getPatientTitle" name="getPatientTitle" />
+    <adapter factory=".analysisrequest.getPatientUID" name="getPatientUID" />
+    <adapter factory=".analysisrequest.getPatientURL" name="getPatientURL" />
+    <adapter factory=".analysisrequest.getClientPatientID" name="getClientPatientID" />
+
     <adapter factory=".analysisrequest.getDoctorUID" name="getDoctorUID" />
+    <adapter factory=".analysisrequest.getDoctorTitle" name="getDoctorTitle" />
+    <adapter factory=".analysisrequest.getDoctorURL" name="getDoctorURL" />
 </configure>

--- a/bika/health/catalog/indexers/configure.zcml
+++ b/bika/health/catalog/indexers/configure.zcml
@@ -1,0 +1,8 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="bika">
+  <unconfigure>
+      <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text" />
+  </unconfigure>
+  <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
+</configure>

--- a/bika/health/configure.zcml
+++ b/bika/health/configure.zcml
@@ -24,7 +24,7 @@
   <include package=".ajax"/>
   <include package=".static"/>
   <include package=".setupdata"/>
-
+  <include package=".catalog.indexers" />
   <include file="profiles.zcml" />
 
   <cmf:registerDirectory name="skins" directory="skins" recursive="True" />

--- a/bika/health/content/analysisrequest.py
+++ b/bika/health/content/analysisrequest.py
@@ -11,7 +11,6 @@ from Products.Archetypes.references import HoldingReference
 from Products.CMFCore import permissions
 from archetypes.schemaextender.interfaces import IOrderableSchemaExtender
 from archetypes.schemaextender.interfaces import ISchemaModifier
-from plone.indexer.decorator import indexer
 from zope.component import adapts
 from zope.interface import implements
 
@@ -23,53 +22,6 @@ from bika.lims.fields import BooleanWidget
 from bika.lims.fields import ExtReferenceField
 from bika.lims.fields import ExtStringField
 from bika.lims.interfaces import IAnalysisRequest
-from bika.lims.interfaces import IBikaCatalog
-from bika.lims.interfaces import IBikaCatalogAnalysisRequestListing
-
-
-# Defining the indexes for this extension. Since this is an extension, no
-# getter is created so we need to create indexes in that way.
-# TODO-catalog: delete this index
-@indexer(IAnalysisRequest, IBikaCatalog)
-def getPatientUID(instance):
-    field = instance.getField('Patient', '')
-    item = field.get(instance) if field else None
-    value = item and item.UID() or ''
-    return value
-
-
-@indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
-def getPatientUID(instance):
-    field = instance.getField('Patient', '')
-    item = field.get(instance) if field else None
-    value = item and item.UID() or ''
-    return value
-
-
-@indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
-def getDoctorUID(instance):
-    field = instance.getField('Doctor', '')
-    item = field.get(instance) if field else None
-    value = item and item.UID() or ''
-    return value
-
-
-# We use this index to sort columns and filter lists
-@indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
-def getPatient(instance):
-    field = instance.getField('Patient', '')
-    item = field.get(instance) if field else None
-    value = item and item.Title() or ''
-    return value
-
-
-# We use this index to sort columns and filter lists
-@indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
-def getPatientID(instance):
-    field = instance.getField('Patient', '')
-    item = field.get(instance) if field else None
-    value = item and item.getId() or ''
-    return value
 
 
 class AnalysisRequestSchemaExtender(object):

--- a/bika/health/content/configure.zcml
+++ b/bika/health/content/configure.zcml
@@ -11,10 +11,6 @@
 
     <adapter factory=".analysisrequest.AnalysisRequestSchemaExtender" />
     <adapter factory=".analysisrequest.AnalysisRequestSchemaModifier" />
-    <adapter factory=".analysisrequest.getPatientUID" name="getPatientUID" />
-    <adapter factory=".analysisrequest.getPatient" name="getPatient" />
-    <adapter factory=".analysisrequest.getPatientID" name="getPatientID" />
-    <adapter factory=".analysisrequest.getDoctorUID" name="getDoctorUID" />
 
     <adapter factory=".batch.BatchSchemaExtender" />
     <adapter factory=".batch.BatchSchemaModifier" />

--- a/bika/health/upgrade/v01_01_002.py
+++ b/bika/health/upgrade/v01_01_002.py
@@ -29,11 +29,16 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF HERE --------
+    ut.delIndexAndColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatient')
+    ut.delIndexAndColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctor')
+
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientID')
-    ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientTitle')
+    ut.addIndexAndColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientTitle',
+                         'FieldIndex')
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientURL')
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getClientPatientID')
-    ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctorTitle')
+    ut.addIndexAndColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctorTitle',
+                         'FieldIndex')
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctorURL')
     ut.refreshCatalogs()
     logger.info("{0} upgraded to version {1}".format(product, version))

--- a/bika/health/upgrade/v01_01_002.py
+++ b/bika/health/upgrade/v01_01_002.py
@@ -9,6 +9,7 @@ from bika.health import logger
 from bika.health.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
+from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 
 version = '1.1.2'
 profile = 'profile-{0}:default'.format(product)
@@ -28,7 +29,13 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF HERE --------
-
+    ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientID')
+    ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientTitle')
+    ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientURL')
+    ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getClientPatientID')
+    ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctorTitle')
+    ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctorURL')
+    ut.refreshCatalogs()
     logger.info("{0} upgraded to version {1}".format(product, version))
 
     return True

--- a/bika/health/utils/__init__.py
+++ b/bika/health/utils/__init__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.HEALTH
+#
+# Copyright 2018 by it's authors.
+# Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
+
+from bika.lims import api
+from bika.lims.api import _marker
+
+
+def get_obj_from_field(instance, fieldname, default=_marker):
+    """ Get an object from a Reference Field of any instance
+    :param fieldname: Reference Field Name
+    :return:
+    """
+    if not fieldname:
+        return default
+    field = instance.getField(fieldname, None)
+    if not field:
+        if default is not _marker:
+            return default
+        api.fail("{} doesn't have field called {} ".format(repr(instance),
+                                                           fieldname))
+    return field.get(instance)
+
+
+def get_attr_from_field(instance, fieldname, attrname, default=None):
+    item = get_obj_from_field(instance, fieldname, None)
+    if not item:
+        return default
+    return api.safe_getattr(instance, attr=attrname, default=default)

--- a/bika/health/utils/__init__.py
+++ b/bika/health/utils/__init__.py
@@ -29,4 +29,4 @@ def get_attr_from_field(instance, fieldname, attrname, default=None):
     item = get_obj_from_field(instance, fieldname, None)
     if not item:
         return default
-    return api.safe_getattr(instance, attr=attrname, default=default)
+    return api.safe_getattr(item, attr=attrname, default=default)


### PR DESCRIPTION
## Current behavior before PR

- Indexers of 'BikaCatalogAnalysisRequestListing' are defined inside 'AnalysisRequest' content class.
- While listing AR's, in order to get columns regarding `Doctor` and `Patient` such as 'DoctorTitle', 'PatientTitle', 'PatientID' and etc., doctor and patient brains are called for each AR which slows down the total rendering time.

## Desired behavior after PR is merged
- Move indexer methods under `catalog/indexers`
- Instead of getting values of related fields from the brains, add metadata to the `BikaCatalogAnalysisRequestListing` and use them directly.
- Also addes more fields from Health Add-on to the new _SearchableText_ field which was introduced in https://github.com/senaite/senaite.core/pull/771 


-----
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
