### PR TITLE
Slow searches for Patient in AR Add view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 **Fixed**
 
 - #71 Slow Reference Widgets in 'Add Case' View
+- #73 Slow Reference Widgets in 'Add AR' View
 - #69 Add proper license to repository
 
 **Security**

--- a/bika/health/content/analysisrequest.py
+++ b/bika/health/content/analysisrequest.py
@@ -74,6 +74,7 @@ class AnalysisRequestSchemaExtender(object):
                          'add': 'edit',
                          'secondary': 'disabled'},
                 catalog_name='bikahealth_catalog_patient_listing',
+                search_fields=('SearchableText',),
                 base_query={'inactive_state': 'active'},
                 colModel = [
                     {'columnName': 'Title', 'width': '30', 'label': _(
@@ -129,7 +130,7 @@ class AnalysisRequestSchemaExtender(object):
                 ui_item='getClientPatientID',
                 search_query='',
                 discard_empty=('ClientPatientID',),
-                search_fields=('ClientPatientID',),
+                search_fields=('getClientPatientID',),
                 portal_types=('Patient',),
                 render_own_label=True,
                 visible={'edit': 'visible',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

While choosing a Patient from 'Add AR' View, it takes too long to retrieve the Patients. The reason is that queries are done by string comparison (because 'Indexes' are not found) which takes too long when there are more than 5000 Patients.

## Desired behavior after PR is merged

Define `search_fields` values properly so brains are queried by indexes instead of filtering by metadata comparison.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
