### PR TITLE
Patient & Doctor URL values in AR Listing Catalog contain 'host' info.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Fixed**
 
+- #75 Patient & Doctor URL values in AR Listing Catalog contain 'host' info.
 - #72 Slow searches in patients list
 - #71 Slow Reference Widgets in 'Add Case' View
 - #73 Slow Reference Widgets in 'Add AR' View

--- a/bika/health/catalog/indexers/analysisrequest.py
+++ b/bika/health/catalog/indexers/analysisrequest.py
@@ -37,7 +37,7 @@ def getPatientID(instance):
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getPatientURL(instance):
     item = get_obj_from_field(instance, 'Patient', None)
-    return item and api.get_url(item) or ''
+    return item and item.absolute_url_path() or ''
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
@@ -58,7 +58,7 @@ def getDoctorTitle(instance):
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
 def getDoctorURL(instance):
     item = get_obj_from_field(instance, 'Doctor', None)
-    return item and api.get_url(item) or ''
+    return item and item.absolute_url_path() or ''
 
 
 @indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)

--- a/bika/health/upgrade/v01_01_002.py
+++ b/bika/health/upgrade/v01_01_002.py
@@ -36,10 +36,12 @@ def upgrade(tool):
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientID')
     ut.addIndexAndColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientTitle',
                          'FieldIndex')
+    ut.delColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientURL')
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientURL')
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getClientPatientID')
     ut.addIndexAndColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctorTitle',
                          'FieldIndex')
+    ut.delColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctorURL')
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctorURL')
     ut.addIndex(CATALOG_PATIENT_LISTING, 'listing_searchable_text', 'TextIndexNG3')
     ut.refreshCatalogs()

--- a/bika/health/upgrade/v01_01_002.py
+++ b/bika/health/upgrade/v01_01_002.py
@@ -36,11 +36,15 @@ def upgrade(tool):
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientID')
     ut.addIndexAndColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientTitle',
                          'FieldIndex')
+
+    # In case if upgrade was already run after PR #72 got accepted
     ut.delColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientURL')
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getPatientURL')
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getClientPatientID')
     ut.addIndexAndColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctorTitle',
                          'FieldIndex')
+
+    # In case if upgrade was already run after PR #72 got accepted
     ut.delColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctorURL')
     ut.addColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'getDoctorURL')
     ut.addIndex(CATALOG_PATIENT_LISTING, 'listing_searchable_text', 'TextIndexNG3')


### PR DESCRIPTION
## Current behavior before PR
`getPatientURL` and `getDoctorURL` columns contains 'host' information.

## Desired behavior after PR is merged
Remove 'host' info from the URL's and just save the path to the Patient & Doctor

----
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
