### PR TITLE
'listing_searchable_text' index optimizations.

### DIFF
--- a/bika/health/catalog/indexers/analysisrequest.py
+++ b/bika/health/catalog/indexers/analysisrequest.py
@@ -60,34 +60,3 @@ def getDoctorURL(instance):
     item = get_obj_from_field(instance, 'Doctor', None)
     return item and api.get_url(item) or ''
 
-
-@indexer(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
-def listing_searchable_text(instance):
-    """ Retrieves all the values of metadata columns in the catalog for
-    wildcard searches
-    :return: all metadata values joined in a string
-    """
-    entries = []
-    catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
-    columns = catalog.schema()
-    failed_columns = []
-    for column in columns:
-        value = api.safe_getattr(instance, column, None)
-        if value is None:
-            failed_columns.append(column)
-            continue
-        parsed = api.to_searchable_text_metadata(value)
-        entries.append(parsed)
-
-    # Getters of senaite.health extension fields are not created. That's why
-    # we are adding them manually
-    for failed_column in failed_columns:
-        getter = globals().get(failed_column, None)
-        if not getter:
-            continue
-        value = getter(instance)()
-        parsed = api.to_searchable_text_metadata(value)
-        entries.append(parsed)
-
-    # Concatenate all strings to one text blob
-    return " ".join(entries)

--- a/bika/health/catalog/indexers/analysisrequest.py
+++ b/bika/health/catalog/indexers/analysisrequest.py
@@ -72,12 +72,9 @@ def listing_searchable_text(instance):
     columns = catalog.schema()
     failed_columns = []
     for column in columns:
-        try:
-            value = api.safe_getattr(instance, column)
-        except:
+        value = api.safe_getattr(instance, column, None)
+        if value is None:
             failed_columns.append(column)
-            continue
-        if not value:
             continue
         parsed = api.to_searchable_text_metadata(value)
         entries.append(parsed)
@@ -87,12 +84,8 @@ def listing_searchable_text(instance):
     for failed_column in failed_columns:
         getter = globals().get(failed_column, None)
         if not getter:
-            logger.error("{} has no attribute called '{}' ".format(
-                            repr(instance), failed_column))
             continue
         value = getter(instance)()
-        if not value:
-            continue
         parsed = api.to_searchable_text_metadata(value)
         entries.append(parsed)
 

--- a/bika/health/catalog/indexers/configure.zcml
+++ b/bika/health/catalog/indexers/configure.zcml
@@ -2,10 +2,6 @@
     xmlns="http://namespaces.zope.org/zope"
     i18n_domain="bika">
 
-    <unconfigure>
-        <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text" />
-    </unconfigure>
-    <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
     <adapter factory=".analysisrequest.getPatientID" name="getPatientID" />
     <adapter factory=".analysisrequest.getPatientTitle" name="getPatientTitle" />
     <adapter factory=".analysisrequest.getPatientUID" name="getPatientUID" />

--- a/bika/health/catalog/indexers/patient.py
+++ b/bika/health/catalog/indexers/patient.py
@@ -19,10 +19,10 @@ def listing_searchable_text(instance):
     entries = []
     catalog = api.get_tool(CATALOG_PATIENT_LISTING)
     columns = catalog.schema()
+    brains = catalog({"UID": api.get_uid(instance)})
 
     for column in columns:
         brain_value = None
-        brains = catalog({"UID": api.get_uid(instance)})
         if brains:
             brain_value = api.safe_getattr(brains[0], column, None)
         instance_value = api.safe_getattr(instance, column, None)

--- a/bika/health/catalog/indexers/patient.py
+++ b/bika/health/catalog/indexers/patient.py
@@ -21,14 +21,7 @@ def listing_searchable_text(instance):
     columns = catalog.schema()
 
     for column in columns:
-        try:
-            value = api.safe_getattr(instance, column)
-        except:
-            logger.debug("{} has no attribute called '{}' ".format(
-                            repr(instance), column))
-            continue
-        if not value:
-            continue
+        value = api.safe_getattr(instance, column, None)
         parsed = api.to_searchable_text_metadata(value)
         entries.append(parsed)
 

--- a/bika/health/catalog/indexers/patient.py
+++ b/bika/health/catalog/indexers/patient.py
@@ -21,8 +21,12 @@ def listing_searchable_text(instance):
     columns = catalog.schema()
 
     for column in columns:
-        value = api.safe_getattr(instance, column, None)
-        parsed = api.to_searchable_text_metadata(value)
+        brain_value = None
+        brains = catalog({"UID": api.get_uid(instance)})
+        if brains:
+            brain_value = api.safe_getattr(brains[0], column, None)
+        instance_value = api.safe_getattr(instance, column, None)
+        parsed = api.to_searchable_text_metadata(brain_value or instance_value)
         entries.append(parsed)
 
     # Concatenate all strings to one text blob

--- a/bika/health/catalog/indexers/patient.py
+++ b/bika/health/catalog/indexers/patient.py
@@ -20,11 +20,9 @@ def listing_searchable_text(instance):
     catalog = api.get_tool(CATALOG_PATIENT_LISTING)
     columns = catalog.schema()
     brains = catalog({"UID": api.get_uid(instance)})
-
+    brain = brains[0] if brains else None
     for column in columns:
-        brain_value = None
-        if brains:
-            brain_value = api.safe_getattr(brains[0], column, None)
+        brain_value = api.safe_getattr(brain, column, None)
         instance_value = api.safe_getattr(instance, column, None)
         parsed = api.to_searchable_text_metadata(brain_value or instance_value)
         entries.append(parsed)


### PR DESCRIPTION
## Current behavior before 
1. 'listing_searchable_text' of AR's is `overriden` in Health.
2. Attributes are obtained directly from the instance instead of brains on Patient indexer.

## Desired behavior after PR is merged
1. AR indexer can be removed because values can be obtained from brains. It will work even for new created objects, because during AR creation, the object is reindexed more than once.
2. In case Patient content type is overriden in another Add-on, it is better to follow the previous approach.

-------
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
