### PR TITLE
Remove Dry Matter references

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changelog
 
 **Removed**
 
+- #77 Remove Dry Matter references
 
 **Fixed**
 

--- a/bika/health/browser/analysisrequest/templates/ar_add_health_standard.pt
+++ b/bika/health/browser/analysisrequest/templates/ar_add_health_standard.pt
@@ -105,16 +105,6 @@
         <input type="hidden" id="copy_to_new_specs" name="copy_to_new_specs" value="{}"
                 tal:attributes="value view/copy_to_new_specs"/>
 
-        <!-- The system configured 'Dry Matter Service' -->
-        <tal:i define="dms python:context.bika_setup.getDryMatterService()">
-            <input type="hidden" id="getDryMatterService" name="getDryMatterService"
-                    tal:condition="nocall:dms"
-                    tal:attributes="
-                            poc python: dms.getPointOfCapture();
-                            cat python: dms.getCategoryUID();
-                            value python: dms.UID()"/>
-        </tal:i>
-
         <input type="hidden"
                id="PhysicalPath"
                 tal:attributes="here python:'/'.join(context.getPhysicalPath()[:-3])"/>

--- a/bika/health/browser/analysisrequest/templates/reports/default.pt
+++ b/bika/health/browser/analysisrequest/templates/reports/default.pt
@@ -14,7 +14,6 @@
                         categanalyses   analysisrequest/categorized_analyses;
                         categqcanalyses analysisrequest/categorized_qcanalyses;
                         hasqcanalyses   python:len(qcanalyses) &gt; 0;
-                        reportdrymatter analysisrequest/report_drymatter;
                         hasprevresults  analysisrequest/haspreviousresults;
                         showqcanalyses  python:view.isQCAnalysesVisible();
                         remarksenabled  python:view.context.bika_setup.getEnableAnalysisRemarks();
@@ -317,7 +316,6 @@
                 <th class="analysis"><span tal:content="string:${cat}">Category</span></th>
                 <th tal:condition="hasprevresults" class="previous"><span i18n:translate="">Previous Results</span></th>
                 <th class="result"><span i18n:translate="">Result</span></th>
-                <th class="dryresult" tal:condition="analysisrequest/report_drymatter"><span i18n:translate="">Dry</span></th>
                 <th class="specs"><span i18n:translate="">Value Range</span></th>
                 <th class="outofrange"></th>
             </tr>
@@ -338,9 +336,6 @@
                     <span class="result" tal:content="analysis/formatted_result">23</span>
                     <span class="units" tal:content="analysis/unit|nothing"></span>
                 </td>
-                <td class="dryresult" tal:condition="python: reportdrymatter and analysis/resultdm">
-                    <span tal:content="string:${analysis/resultdm}  ${analysis/unit|nothing}">23</span>
-                </td>
                 <td class="specs">
                     <span tal:condition="analysis/uncertainty"
                           tal:replace="string:[&plusmn; ${analysis/formatted_uncertainty}] "></span>
@@ -353,7 +348,6 @@
             </tr>
             <tr tal:condition="python:remarksenabled==True and analysis['remarks']">
                 <td class="remarks" colspan="5"
-                    tal:attributes="colspan python: '6' if reportdrymatter else '5';"
                     tal:content="structure analysis/remarks">
                     Quisque sodales quam quis faucibus pretium. Aliquam erat volutpat. Pellentesque vel gravida nibh. Curabitur scelerisque cursus pretium. Mauris sollicitudin, risus vitae tincidunt fringilla, nisi risus consequat dolor, a laoreet dui odio eget elit. Etiam metus orci, sagittis sit amet metus in, tempus viverra ipsum. Nulla sed mi pharetra, hendrerit turpis quis, hendrerit elit. In vel eleifend arcu. Phasellus at imperdiet dui, quis mattis velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
                 </td>
@@ -385,7 +379,6 @@
                 <tr>
                     <th class="analysis"><span tal:content='python: cat'>Category: Vitamin D</span></th>
                     <th class="result"><span i18n:translate="">Result</span></th>
-                    <th class="dryresult" tal:condition="analysisrequest/report_drymatter"><span i18n:translate="">Dry</span></th>
                     <th class="specs"><span i18n:translate="">Value Range</span></th>
                     <th class="refsample" tal:condition='python: duplicate==False'><span i18n:translate="">Reference Sample</span></th>
                     <th class="worksheet"><span i18n:translate="">Worksheet</span></th>
@@ -404,9 +397,6 @@
                 <td>
                     <span class="result" tal:content="analysis/formatted_result">23</span>
                     <span class="units" tal:content="analysis/unit|nothing"></span>
-                </td>
-                <td class="dryresult" tal:condition="python: reportdrymatter and analysis/resultdm">
-                    <span tal:content="string:${analysis/resultdm}  ${analysis/unit|nothing}">23</span>
                 </td>
                 <td class="specs">
                     <span tal:condition="analysis/uncertainty"
@@ -577,7 +567,6 @@
 <!-- Discreeter section -->
 <div id="section-discreeter">
     <div id="discreeter-outofrange" i18n:translate="">* Result out of client specified range.</div>
-    <div tal:condition="analysisrequest/report_drymatter" i18n:translate="">Reported as dry matter</div>
     <div tal:condition="analysisrequest/invoice_exclude" i18n:translate="">Not invoiced</div>
     <div tal:condition="laboratory/accredited" i18n:translate="">Methods included in the <tal:block replace="laboratory/accreditation_body" i18n:name="accreditation_body"/> schedule of Accreditation for this Laboratory. Analysis remarks are not accredited</div>
     <div i18n:translate="">Analysis results relate only to the samples tested.</div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Remove Dry Matter references since this functionality has been removed from `senaite.core`. 
See P.R: https://github.com/senaite/senaite.core/pull/779

## Current behavior before PR

There are some Dry Matter references in the code

## Desired behavior after PR is merged

Dry Matter references are are removed from the code

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
