### PR TITLE
Include Travis badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@
 .. image:: https://img.shields.io/pypi/v/senaite.health.svg?style=flat-square
     :target: https://pypi.python.org/pypi/senaite.health
 
+.. image:: https://travis-ci.org/senaite/senaite.health.svg?branch=master
+    :target: https://travis-ci.org/senaite/senaite.health
+
 .. image:: https://img.shields.io/scrutinizer/g/senaite/senaite.health/master.svg?style=flat-square
     :target: https://scrutinizer-ci.com/g/senaite/senaite.health/
     


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Include Travis build badge in the readme 

## Current behavior before PR

Travis build badge is not included in the readme

## Desired behavior after PR is merged

Travis badge is included in the readme and, hopefully, the build state is passing.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
