### PR TITLE
Remove dependency to senaite.core's MultiFileView

### DIFF
--- a/bika/health/browser/patient/files.py
+++ b/bika/health/browser/patient/files.py
@@ -4,20 +4,106 @@
 #
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
-
+from ZODB.POSException import POSKeyError
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_link
 from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.layout.globals.interfaces import IViewView
 from zope.interface import implements
-from bika.lims.browser.multifile import MultifileView
 
 
-class PatientMultifileView(MultifileView):
+class PatientMultifileView(BikaListingView):
     implements(IFolderContentsView, IViewView)
 
     def __init__(self, context, request):
         super(PatientMultifileView, self).__init__(context, request)
-        self.title = self.context.translate(_("Patient Attachments"))
-        self.context_actions = {_('Add'):
-                                {'url': 'createObject?type_name=Multifile',
-                                 'icon': '++resource++bika.lims.images/add.png'}}
+
+        self.catalog = "bika_setup_catalog"
+        self.contentFilter = {
+            "portal_type": "Multifile",
+            "path": {
+                "query": api.get_path(context),
+                "depth": 1  # searching just inside the specified folder
+            },
+            "sort_on": "created",
+            "sort_order": "descending",
+        }
+
+        self.form_id = "patientfiles"
+        self.title = self.context.translate(_("Patient Files"))
+        self.icon = "{}/{}".format(
+            self.portal_url,
+            "++resource++bika.lims.images/instrumentcertification_big.png"
+        )
+        self.context_actions = {
+            _("Add"): {
+                "url": "createObject?type_name=Multifile",
+                "icon": "++resource++bika.lims.images/add.png"
+            }
+        }
+
+        self.allow_edit = False
+        self.show_select_column = False
+        self.show_workflow_action_buttons = True
+        self.pagesize = 30
+
+        self.columns = {
+            "DocumentID": {"title": _("Document ID"),
+                           "index": "sortable_title"},
+            "DocumentVersion": {"title": _("Document Version"),
+                                "index": "sortable_title"},
+            "DocumentLocation": {"title": _("Document Location"),
+                                 "index": "sortable_title"},
+            "DocumentType": {"title": _("Document Type"),
+                             "index": "sortable_title"},
+            "FileDownload": {"title": _("File")}
+        }
+
+        self.review_states = [
+            {
+                "id": "default",
+                "title": _("All"),
+                "contentFilter": {},
+                "columns": [
+                    "DocumentID",
+                    "DocumentVersion",
+                    "DocumentLocation",
+                    "DocumentType",
+                    "FileDownload"
+                ]
+            },
+        ]
+
+    def get_file(self, obj):
+        """Return the file of the given object
+        """
+        try:
+            return obj.getFile()
+        except POSKeyError:  # POSKeyError: "No blob file"
+            # XXX When does this happen?
+            return None
+
+    def folderitem(self, obj, item, index):
+        """Augment folder listing item with additional data
+        """
+        url = item.get("url")
+        title = item.get("DocumentID")
+
+        item["replace"]["DocumentID"] = get_link(url, title)
+
+        item["FileDownload"] = ""
+        item["replace"]["FileDownload"] = ""
+        file = self.get_file(obj)
+        if file and file.get_size() > 0:
+            filename = file.filename
+            download_url = "{}/at_download/File".format(url)
+            anchor = get_link(download_url, filename)
+            item["FileDownload"] = filename
+            item["replace"]["FileDownload"] = anchor
+
+        item["DocumentVersion"] = obj.getDocumentVersion()
+        item["DocumentLocation"] = obj.getDocumentLocation()
+        item["DocumentType"] = obj.getDocumentType()
+        return item


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`MultiFileView` has been removed from `senaite.core` recently as per ["Instrument Listing Views Fixes and Refactoring" senaite.core@461290e](https://github.com/senaite/senaite.core/pull/824).

## Current behavior before PR

```
Traceback (most recent call last):
  File "/home/xispa/zinstance/parts/instance/bin/interpreter", line 333, in <module>
    exec(compile(__file__f.read(), __file__, "exec"))
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/Startup/run.py", line 76, in <module>
    run()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/Startup/run.py", line 22, in run
    starter.prepare()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/Startup/__init__.py", line 92, in prepare
    self.startZope()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/Startup/__init__.py", line 268, in startZope
    Zope2.startup()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/__init__.py", line 47, in startup
    _startup()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/App/startup.py", line 120, in startup
    load_zcml()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/App/startup.py", line 52, in load_zcml
    load_site()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/App/zcml.py", line 46, in load_site
    _context = xmlconfig.file(site_zcml)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 649, in file
    include(context, name, package)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 548, in include
    processxmlfile(f, context)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 380, in processxmlfile
    parser.parse(src)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 107, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/usr/lib/python2.7/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 210, in feed
    self._parser.Parse(data, isFinal)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 352, in end_element_ns
    self._cont_handler.endElementNS(pair, None)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 359, in endElementNS
    self.context.end()
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 558, in end
    self.stack.pop().finish()
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 706, in finish
    actions = self.handler(context, **args)
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/metaconfigure.py", line 46, in loadProducts
    xmlconfig.include(_context, zcml, package=product)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 548, in include
    processxmlfile(f, context)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 380, in processxmlfile
    parser.parse(src)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 107, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/usr/lib/python2.7/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 210, in feed
    self._parser.Parse(data, isFinal)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 352, in end_element_ns
    self._cont_handler.endElementNS(pair, None)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 359, in endElementNS
    self.context.end()
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 558, in end
    self.stack.pop().finish()
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 706, in finish
    actions = self.handler(context, **args)
  File "/home/xispa/buildout-cache/eggs/z3c.autoinclude-0.3.5-py2.7.egg/z3c/autoinclude/zcml.py", line 104, in includePluginsDirective
    includeZCMLGroup(_context, info, filename)
  File "/home/xispa/buildout-cache/eggs/z3c.autoinclude-0.3.5-py2.7.egg/z3c/autoinclude/zcml.py", line 30, in includeZCMLGroup
    include(_context, filename, includable_package)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 548, in include
    processxmlfile(f, context)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 380, in processxmlfile
    parser.parse(src)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 107, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/usr/lib/python2.7/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 210, in feed
    self._parser.Parse(data, isFinal)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 352, in end_element_ns
    self._cont_handler.endElementNS(pair, None)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 359, in endElementNS
    self.context.end()
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 558, in end
    self.stack.pop().finish()
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 706, in finish
    actions = self.handler(context, **args)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 548, in include
    processxmlfile(f, context)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 380, in processxmlfile
    parser.parse(src)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 107, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/usr/lib/python2.7/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 210, in feed
    self._parser.Parse(data, isFinal)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 352, in end_element_ns
    self._cont_handler.endElementNS(pair, None)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 359, in endElementNS
    self.context.end()
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 558, in end
    self.stack.pop().finish()
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 706, in finish
    actions = self.handler(context, **args)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 548, in include
    processxmlfile(f, context)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 380, in processxmlfile
    parser.parse(src)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 107, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/usr/lib/python2.7/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 210, in feed
    self._parser.Parse(data, isFinal)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 352, in end_element_ns
    self._cont_handler.endElementNS(pair, None)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/xmlconfig.py", line 359, in endElementNS
    self.context.end()
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 558, in end
    self.stack.pop().finish()
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 705, in finish
    args = toargs(context, *self.argdata)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 1397, in toargs
    args[str(name)] = field.fromUnicode(s)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/fields.py", line 137, in fromUnicode
    value = self.context.resolve(name)
  File "/home/xispa/buildout-cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py", line 179, in resolve
    mod = __import__(mname, *_import_chickens)
  File "/home/xispa/zinstance/src/senaite.health/bika/health/browser/patient/files.py", line 12, in <module>
    from bika.lims.browser.multifile import MultifileView
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/home/xispa/zinstance/parts/instance/etc/site.zcml", line 16.2-16.23
    ZopeXMLConfigurationError: File "/home/xispa/buildout-cache/eggs/Products.CMFPlone-4.3.15-py2.7.egg/Products/CMFPlone/configure.zcml", line 98.4-102.10
    ZopeXMLConfigurationError: File "/home/xispa/zinstance/src/senaite.health/bika/health/configure.zcml", line 23.2-23.31
    ZopeXMLConfigurationError: File "/home/xispa/zinstance/src/senaite.health/bika/health/browser/configure.zcml", line 25.2-25.31
    ZopeXMLConfigurationError: File "/home/xispa/zinstance/src/senaite.health/bika/health/browser/patient/configure.zcml", line 97.4-103.6
    ImportError: No module named multifile
```


## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
