### PR TITLE
Traceback when importing diseases with setupdata.xlsx

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #81 Traceback when importing diseases with setupdata.xlsx
 
 **Security**
 

--- a/bika/health/setupdata/__init__.py
+++ b/bika/health/setupdata/__init__.py
@@ -229,7 +229,7 @@ class Case_Statuses(WorksheetImporter):
 class Diseases(WorksheetImporter):
 
     def Import(self):
-        folder = self.context.bika_setup.bika_symptoms
+        folder = self.context.bika_setup.bika_diseases
         rows = self.get_rows(3)
         for row in rows:
             _id = folder.invokeFactory('Disease', id=tmpID())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback when importing diseases with setupdata.xlsx. Cannot add diseases inside Symptom's folder.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
