### PR TITLE
Cleanup skins configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #82 Inconsistent behavior with health' skins priority over core's
 
 **Security**
 

--- a/bika/health/configure.zcml
+++ b/bika/health/configure.zcml
@@ -29,24 +29,4 @@
 
   <cmf:registerDirectory name="skins" directory="skins" recursive="True" />
 
-  <browser:resource
-    file="skins/bika_health/logo.png"
-    name="bika-health-logo.png"
-   />
-
-  <browser:resource
-    file="skins/bika_health/logo.png"
-    name="logo.png"
-  />
-
-  <browser:resource
-      file="skins/bika_health/senaite-health-logo.png"
-      name="senaite-core-logo.png"
-  />
-
-  <browser:resource
-      file="skins/bika_health/senaite-health-hexagon-logo.png"
-      name="senaite-hexagon-logo.png"
-  />
-
 </configure>

--- a/bika/health/overrides.zcml
+++ b/bika/health/overrides.zcml
@@ -15,24 +15,5 @@
     <include file="static/overrides.zcml" />
     <include file="setupdata/overrides.zcml" />
 
-    <browser:resource
-        file="skins/bika_health/logo.png"
-        name="bika-lims-logo.png"
-    />
-
-    <browser:resource
-        file="skins/bika_health/logo.png"
-        name="logo.png"
-    />
-
-    <browser:resource
-        file="skins/bika_health/senaite-health-logo.png"
-        name="senaite-core-logo.png"
-    />
-
-    <browser:resource
-        file="skins/bika_health/senaite-health-hexagon-logo.png"
-        name="senaite-hexagon-logo.png"
-    />
 
 </configure>

--- a/bika/health/profiles.zcml
+++ b/bika/health/profiles.zcml
@@ -8,6 +8,7 @@
       title="SENAITE Health"
       directory="profiles/default"
       description='Health Care extension for SENAITE Core'
+      post_handler="bika.health.setuphandlers.post_install"
       provides="Products.GenericSetup.interfaces.EXTENSION"/>
 
   <genericsetup:importStep

--- a/bika/health/profiles/default/skins.xml
+++ b/bika/health/profiles/default/skins.xml
@@ -11,7 +11,7 @@
           directory="bika.health:skins/bika_health"/>
 
   <skin-path name="*">
-    <layer name="bika_health" insert-before="custom"/>
+    <layer name="bika_health" insert-before="bika"/>
   </skin-path>
 
 </object>

--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -378,13 +378,15 @@ def post_install(portal_setup):
 
     :param portal_setup: SetupTool
     """
-    logger.info("SENAITE Health install handler [BEGIN]")
+    logger.info("SENAITE Health post-install handler [BEGIN]")
 
-    # Ensure health's skin layer(s) gets priority over core's
+    # When installing senaite health together with core, health's skins are not
+    # set before core's, even if after-before is set in profiles/skins.xml
+    # Ensure health's skin layer(s) always gets priority over core's
     profile = 'profile-{0}:default'.format(product)
     portal_setup.runImportStepFromProfile(profile, "skins")
 
-    logger.info("SENAITE Health install handler [DONE]")
+    logger.info("SENAITE Health post-install handler [DONE]")
 
 
 def setupHealthTestContent(context):

--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -19,6 +19,7 @@ from bika.lims.catalog\
 from bika.health.catalog\
     import getCatalogDefinitions as getCatalogDefinitionsHealth
 from bika.health.catalog import getCatalogExtensions
+from bika.health.config import PROJECTNAME as product
 from bika.lims.utils import tmpID
 from bika.lims.idserver import renameAfterCreation
 from bika.health.permissions import AddAetiologicAgent
@@ -368,6 +369,22 @@ def setupHealthCatalogs(context):
     setup_catalogs(
         portal, catalog_definitions_lims_health,
         catalogs_extension=getCatalogExtensions())
+
+
+def post_install(portal_setup):
+    """Runs after the last import step of the *default* profile
+
+    This handler is registered as a *post_handler* in the generic setup profile
+
+    :param portal_setup: SetupTool
+    """
+    logger.info("SENAITE Health install handler [BEGIN]")
+
+    # Ensure health's skin layer(s) gets priority over core's
+    profile = 'profile-{0}:default'.format(product)
+    portal_setup.runImportStepFromProfile(profile, "skins")
+
+    logger.info("SENAITE Health install handler [DONE]")
 
 
 def setupHealthTestContent(context):

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -28,6 +28,9 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF HERE --------
+    # Ensure health's skins have always priority over core's
+    setup = portal.portal_setup
+    setup.runImportStepFromProfile(profile, "skins")
 
     logger.info("{0} upgraded to version {1}".format(product, version))
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When installing senaite health together with core, health's skins are not set before core's, even if `after-before` is set in profiles/skins.xml. This PR ensures health's skin layer(s) always gets priority over core's.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
