### PR TITLE
Allow client contact to create and edit Doctors.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #83 Allow client contact to create and edit Doctors
 
 **Changed**
 

--- a/bika/health/browser/client/configure.zcml
+++ b/bika/health/browser/client/configure.zcml
@@ -12,4 +12,12 @@
       layer="bika.lims.interfaces.IBikaLIMS"
     />
 
+    <browser:page
+      for="bika.lims.interfaces.IClient"
+      name="doctors"
+      class="bika.health.browser.client.doctors.ClientDoctorsView"
+      permission="zope2.View"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
 </configure>

--- a/bika/health/browser/client/doctors.py
+++ b/bika/health/browser/client/doctors.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.HEALTH
+#
+# Copyright 2018 by it's authors.
+# Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
+
+from bika.health.browser.doctors.folder_view import DoctorsView
+
+
+class ClientDoctorsView(DoctorsView):
+
+    def __init__(self, context, request):
+        DoctorsView.__init__(self, context, request)
+
+        # Limit results to those patients that "belong" to this client
+        self.contentFilter['getPrimaryReferrerUID'] = context.UID()

--- a/bika/health/browser/doctors/folder_view.py
+++ b/bika/health/browser/doctors/folder_view.py
@@ -102,6 +102,10 @@ class DoctorsView(ClientContactsView):
         return items
 
     def _apply_filter_by_client(self):
+        """
+        From the current user and the context, update the filter that will be
+        used for filtering the Doctor's list.
+        """
         # If the current context is a Client, filter Doctors by Client UID
         if IClient.providedBy(self.context):
             client_uid = api.get_uid(self.context)

--- a/bika/health/browser/doctors/folder_view.py
+++ b/bika/health/browser/doctors/folder_view.py
@@ -6,10 +6,12 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from Products.CMFCore.utils import getToolByName
-from bika.lims import bikaMessageFactory as _b
+
 from bika.health import bikaMessageFactory as _
-from bika.lims.browser.client import ClientContactsView
 from bika.health.permissions import *
+from bika.lims import api
+from bika.lims.browser.client import ClientContactsView
+from bika.lims.interfaces import IClient, ILabContact
 
 
 class DoctorsView(ClientContactsView):
@@ -80,6 +82,7 @@ class DoctorsView(ClientContactsView):
                              'getMobilePhone']})
             stat = self.request.get("%s_review_state"%self.form_id, 'default')
             self.show_select_column = stat != 'all'
+        self._apply_filter_by_client()
         return super(DoctorsView, self).__call__()
 
     def folderitems(self):
@@ -94,3 +97,32 @@ class DoctorsView(ClientContactsView):
                  (items[x]['url'], items[x]['getFullname'])
 
         return items
+
+    def _apply_filter_by_client(self):
+        # If the current context is a Client, filter Doctors by Client UID
+        if IClient.providedBy(self.context):
+            client_uid = api.get_uid(self.context)
+            self.contentFilter['getPrimaryReferrerUID'] = client_uid
+            return
+
+        # If the current user is a Client contact, filter the Doctors in
+        # accordance. For the rest of users (LabContacts), the visibility of
+        # the doctors depend on their permissions
+        user = api.get_current_user()
+        roles = user.getRoles()
+        if 'Client' not in roles:
+            return
+
+        # Are we sure this a ClientContact?
+        # May happen that this is a Plone member, w/o having a ClientContact
+        # assigned or having a LabContact assigned... weird
+        contact = api.get_user_contact(user)
+        if not contact or ILabContact.providedBy(contact):
+            return
+
+        # Is the parent from the Contact a Client?
+        client = api.get_parent(contact)
+        if not client or not IClient.providedBy(client):
+            return
+        client_uid = api.get_uid(client)
+        self.contentFilter['getPrimaryReferrerUID'] = client_uid

--- a/bika/health/browser/doctors/folder_view.py
+++ b/bika/health/browser/doctors/folder_view.py
@@ -53,9 +53,12 @@ class DoctorsView(ClientContactsView):
 
     def __call__(self):
         mtool = getToolByName(self.context, 'portal_membership')
-        if mtool.checkPermission(AddDoctor, self.context):
+        can_add_doctors = mtool.checkPermission(AddDoctor, self.context)
+        if can_add_doctors:
+            add_doctors_url = '{}/doctors/createObject?type_name=Doctor' \
+                .format(self.portal_url)
             self.context_actions[_('Add')] = {
-                'url': 'createObject?type_name=Doctor',
+                'url': add_doctors_url,
                 'icon': '++resource++bika.lims.images/add.png'
             }
         if mtool.checkPermission(ManageDoctors, self.context):

--- a/bika/health/content/doctor.py
+++ b/bika/health/content/doctor.py
@@ -35,7 +35,7 @@ schema = Contact.schema.copy() + Schema((
         'PrimaryReferrer',
         vocabulary='get_clients',
         allowed_types=('Client',),
-        relationship='PatientClient',
+        relationship='DoctorClient',
         required=0,
         widget=SelectionWidget(
             format='select',
@@ -78,6 +78,12 @@ class Doctor(Contact):
         clients.sort(lambda x, y: cmp(x[1].lower(), y[1].lower()))
         clients.insert(0, ['', ''])
         return DisplayList(clients)
+
+    def getPrimaryReferrerUID(self):
+        primary_referrer = self.getPrimaryReferrer()
+        if primary_referrer:
+            return primary_referrer.UID()
+
 
 # schemata.finalizeATCTSchema(schema, folderish=True, moveDiscussion=False)
 

--- a/bika/health/content/doctor.py
+++ b/bika/health/content/doctor.py
@@ -18,6 +18,8 @@ from Products.Archetypes.public import StringWidget
 from Products.CMFCore.utils import getToolByName
 from zope.interface import implements
 
+from bika.lims import api
+
 from bika.health import bikaMessageFactory as _
 from bika.health.config import *
 from bika.health.interfaces import IDoctor
@@ -68,7 +70,7 @@ class Doctor(Contact):
 
     def get_clients(self):
         # Only show clients to which we have Manage AR rights.
-        mtool = getToolByName(self, 'portal_membership')
+        mtool = api.get_tool('portal_membership')
         clientfolder = self.clients
         clients = []
         for client in clientfolder.objectValues("Client"):

--- a/bika/health/content/doctor.py
+++ b/bika/health/content/doctor.py
@@ -73,15 +73,10 @@ class Doctor(Contact):
         Vocabulary list with clients which the user has Manage AR rights.
         :return: A DisplayList object
         """
-        # Only show clients to which we have Manage AR rights.
-        mtool = api.get_tool('portal_membership')
-        clientfolder = self.clients
-        clients = []
-        for client in clientfolder.objectValues("Client"):
-            if not mtool.checkPermission(ManageAnalysisRequests, client):
-                continue
-            clients.append([client.UID(), client.Title()])
-        clients.sort(key=lambda x: x[1].lower())
+        query = dict(portal_type='Client', inactive_state='active', sort_order='ascending',
+                     sort_on='title')
+        brains = api.search(query, 'portal_catalog')
+        clients = map(lambda brain: [api.get_uid(brain), brain.Title], brains)
         clients.insert(0, ['', ''])
         return DisplayList(clients)
 

--- a/bika/health/content/doctor.py
+++ b/bika/health/content/doctor.py
@@ -69,6 +69,10 @@ class Doctor(Contact):
         return [p.getObject() for p in bc(portal_type='AnalysisRequest', getDoctorUID=self.UID())]
 
     def get_clients(self):
+        """
+        Vocabulary list with clients which the user has Manage AR rights.
+        :return: A DisplayList object
+        """
         # Only show clients to which we have Manage AR rights.
         mtool = api.get_tool('portal_membership')
         clientfolder = self.clients

--- a/bika/health/content/doctor.py
+++ b/bika/health/content/doctor.py
@@ -77,7 +77,7 @@ class Doctor(Contact):
             if not mtool.checkPermission(ManageAnalysisRequests, client):
                 continue
             clients.append([client.UID(), client.Title()])
-        clients.sort(lambda x, y: cmp(x[1].lower(), y[1].lower()))
+        clients.sort(key=lambda x: x[1].lower())
         clients.insert(0, ['', ''])
         return DisplayList(clients)
 

--- a/bika/health/content/doctors.py
+++ b/bika/health/content/doctors.py
@@ -5,22 +5,17 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.ATContentTypes.content import schemata
+import json
+
 from Products.Archetypes import atapi
-from Products.CMFCore import permissions
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser import BrowserView
-from bika.lims.browser.bika_listing import BikaListingView
 from Products.Archetypes.utils import DisplayList
-from bika.health.config import PROJECTNAME
-from bika.health.interfaces import IDoctors
-from plone.app.layout.globals.interfaces import IViewView
-from bika.lims import bikaMessageFactory as _b
-from bika.health import bikaMessageFactory as _
-from bika.health.permissions import *
+from Products.CMFCore.utils import getToolByName
 from plone.app.folder.folder import ATFolder, ATFolderSchema
 from zope.interface.declarations import implements
-import json
+
+from bika.health.config import PROJECTNAME
+from bika.health.interfaces import IDoctors
+from bika.lims.utils import isActive
 
 schema = ATFolderSchema.copy()
 

--- a/bika/health/profiles/default/workflows/bika_doctor_workflow/definition.xml
+++ b/bika/health/profiles/default/workflows/bika_doctor_workflow/definition.xml
@@ -23,6 +23,7 @@
    <permission-role>Preserver</permission-role>
    <permission-role>Owner</permission-role>
    <permission-role>Doctor</permission-role>
+   <permission-role>Client</permission-role>
   </permission-map>
   <permission-map name="Change portal events" acquired="False">
    <permission-role>Manager</permission-role>
@@ -33,6 +34,7 @@
    <permission-role>Preserver</permission-role>
    <permission-role>Owner</permission-role>
    <permission-role>Doctor</permission-role>
+   <permission-role>Client</permission-role>
   </permission-map>
   <permission-map name="Modify portal content" acquired="False">
    <permission-role>Manager</permission-role>
@@ -43,6 +45,7 @@
    <permission-role>Preserver</permission-role>
    <permission-role>Owner</permission-role>
    <permission-role>Doctor</permission-role>
+   <permission-role>Client</permission-role>
   </permission-map>
   <permission-map name="View" acquired="False">
    <permission-role>Manager</permission-role>
@@ -53,6 +56,7 @@
    <permission-role>Preserver</permission-role>
    <permission-role>Owner</permission-role>
    <permission-role>Doctor</permission-role>
+   <permission-role>Client</permission-role>
   </permission-map>
  </state>
 

--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -270,7 +270,7 @@ def setupHealthPermissions(context):
     mp(CancelAndReinstate, ['Manager', 'LabManager', 'LabClerk'], 0)
     mp('Access contents information', ['Manager', 'LabManager', 'Member', 'LabClerk', 'Doctor', 'Analyst', 'Sampler', 'Preserver', 'Owner'], 0)
     mp(permissions.ListFolderContents, ['Manager', 'LabManager', 'LabClerk', 'LabTechnician', 'Doctor', 'Owner', 'Sampler', 'Preserver'], 0)
-    mp(permissions.View, ['Manager', 'LabManager', 'LabClerk', 'LabTechnician', 'Doctor', 'Owner', 'Sampler', 'Preserver'], 0)
+    mp(permissions.View, ['Manager', 'LabManager', 'LabClerk', 'LabTechnician', 'Doctor', 'Owner', 'Sampler', 'Preserver', 'Client'], 0)
     portal.doctors.reindexObject()
 
     # /reports folder permissions

--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -148,7 +148,7 @@ def setupHealthVarious(context):
     client = portal.portal_types.getTypeInfo("Client")
     client.addAction(
         id="doctors",
-        name="Doctor",
+        name="Doctors",
         action="string:${object_url}/doctors",
         permission=permissions.View,
         category="object",
@@ -203,7 +203,7 @@ def setupHealthPermissions(context):
     mp(AddAnalysisRequest, ['Manager', 'Owner', 'LabManager', 'LabClerk', 'Doctor', 'Sampler'], 1)
     mp(AddSample, ['Manager', 'Owner', 'LabManager', 'LabClerk', 'Doctor', 'Sampler'], 1)
     mp(AddSamplePartition, ['Manager', 'Owner', 'LabManager', 'LabClerk', 'Doctor', 'Sampler'], 1)
-    mp(AddDoctor, ['Manager', 'Owner', 'LabManager', 'LabClerk'], 1)
+    mp(AddDoctor, ['Manager', 'Owner', 'LabManager', 'LabClerk', 'Client'], 0)
     mp(AddAetiologicAgent, ['Manager', 'Owner', 'LabManager', 'LabClerk'], 1)
     mp(AddTreatment, ['Manager', 'Owner', 'LabManager', 'LabClerk'], 1)
     mp(AddDrug, ['Manager', 'Owner', 'LabManager', 'LabClerk'], 1)

--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -349,6 +349,7 @@ def setupHealthCatalogs(context):
         return
     addIndex(pc, 'getDoctorID', 'FieldIndex')
     addIndex(pc, 'getDoctorUID', 'FieldIndex')
+    addIndex(pc, 'getPrimaryReferrerUID', 'FieldIndex')
     addColumn(pc, 'getDoctorID')
     addColumn(pc, 'getDoctorUID')
 

--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -144,6 +144,20 @@ def setupHealthVarious(context):
         description="",
         condition="")
 
+    # Add doctor action for client portal_type programmatically
+    client = portal.portal_types.getTypeInfo("Client")
+    client.addAction(
+        id="doctors",
+        name="Doctor",
+        action="string:${object_url}/doctors",
+        permission=permissions.View,
+        category="object",
+        visible=True,
+        icon_expr="string:${portal_url}/images/doctor.png",
+        link_target="",
+        description="",
+        condition="")
+
     setupEthnicities(bika_setup)
 
 

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -35,6 +35,8 @@ def upgrade(tool):
     setup.runImportStepFromProfile(profile, "skins")
 
     add_doctor_action_for_client(portal)
+    ut.addIndex('portal_catalog', 'getPrimaryReferrerUID', 'FieldIndex')
+    ut.refreshCatalogs()
 
     logger.info("{0} upgraded to version {1}".format(product, version))
 

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -87,14 +87,14 @@ def update_permissions_clients(portal):
         "Changing permissions for doctor objects: {0}".format(total))
     for brain in brains:
         if 'Client' not in brain.allowedRolesAndUsers:
-            if counter % 100 == 0:
-                logger.info(
-                    "Changing permissions for doctor objects: " +
-                    "{0}/{1}".format(counter, total))
             obj = api.get_object(brain)
             workflow.updateRoleMappingsFor(obj)
             obj.reindexObject()
         counter += 1
+        if counter % 100 == 0:
+            logger.info(
+                "Changing permissions for doctor objects: " +
+                "{0}/{1}".format(counter, total))
     logger.info(
         "Changed permissions for doctor objects: " +
         "{0}/{1}".format(counter, total))

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -36,7 +36,6 @@ def upgrade(tool):
     setup = portal.portal_setup
     setup.runImportStepFromProfile(profile, "skins")
     setup.runImportStepFromProfile(profile, 'workflow')
-    setup.runImportStepFromProfile(profile, 'propertiestool')
 
     add_doctor_action_for_client(portal)
 

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -39,11 +39,8 @@ def upgrade(tool):
     setup.runImportStepFromProfile(profile, 'propertiestool')
 
     add_doctor_action_for_client(portal)
-    ut.addIndexAndColumn('portal_catalog', 'allowedRolesAndUsers', 'FieldIndex')
-    ut.addIndex('portal_catalog', 'getPrimaryReferrerUID', 'FieldIndex')
-    ut.refreshCatalogs()
 
-    update_permissions_clients(portal)
+    update_permissions_clients(portal, ut)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
 
@@ -75,15 +72,22 @@ def add_doctor_action_for_client(portal):
     logger.info("'doctor' action for client portal_type added")
 
 
-def update_permissions_clients(portal):
+def update_permissions_clients(portal, ut):
     """
-    Maps and updates the permissions for clients.
+    Maps and updates the permissions for clients and doctors.
+    :param portal: The portal object
+    :param ut: UpgradeUtils object
 
     :return: None
     """
     workflow_tool = api.get_tool("portal_workflow")
     workflow = workflow_tool.getWorkflowById('bika_doctor_workflow')
     catalog = api.get_tool('portal_catalog')
+
+    # Adding new index and columns in portal_catalog for doctors
+    ut.addIndexAndColumn('portal_catalog', 'allowedRolesAndUsers', 'FieldIndex')
+    ut.addIndex('portal_catalog', 'getPrimaryReferrerUID', 'FieldIndex')
+
     brains = catalog(portal_type='Doctor')
     counter = 0
     total = len(brains)

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -108,3 +108,4 @@ def update_permissions_clients(portal):
        ['Manager', 'LabManager', 'LabClerk', 'LabTechnician',
         'Doctor', 'Owner', 'Sampler', 'Preserver', 'Client'], 0)
     mp(AddDoctor, ['Manager', 'Owner', 'LabManager', 'LabClerk', 'Client'], 0)
+    portal.doctors.reindexObject()

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -51,7 +51,11 @@ def upgrade(tool):
 
 
 def add_doctor_action_for_client(portal):
-    # Add doctor action for client portal_type programmatically
+    """
+    Adds doctor action for client portal_type programmatically
+    :param portal: The portal object
+    :return: None
+    """
     client = portal.portal_types.getTypeInfo("Client")
     for action in client.listActionInfos():
         if action.get('id', None) == 'doctors':

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -9,6 +9,7 @@ from Products.CMFCore import permissions
 
 from bika.health import logger
 from bika.health.config import PROJECTNAME as product
+from bika.health.permissions import AddDoctor
 from bika.lims import api
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
@@ -58,7 +59,7 @@ def add_doctor_action_for_client(portal):
             return None
     client.addAction(
         id="doctors",
-        name="Doctor",
+        name="Doctors",
         action="string:${object_url}/doctors",
         permission=permissions.View,
         category="object",
@@ -102,4 +103,4 @@ def update_permissions_clients(portal):
     mp(permissions.View,
        ['Manager', 'LabManager', 'LabClerk', 'LabTechnician',
         'Doctor', 'Owner', 'Sampler', 'Preserver', 'Client'], 0)
-
+    mp(AddDoctor, ['Manager', 'Owner', 'LabManager', 'LabClerk', 'Client'], 0)

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -9,6 +9,7 @@ from Products.CMFCore import permissions
 
 from bika.health import logger
 from bika.health.config import PROJECTNAME as product
+from bika.lims import api
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
 
@@ -33,10 +34,15 @@ def upgrade(tool):
     # Ensure health's skins have always priority over core's
     setup = portal.portal_setup
     setup.runImportStepFromProfile(profile, "skins")
+    setup.runImportStepFromProfile(profile, 'workflow')
+    setup.runImportStepFromProfile(profile, 'propertiestool')
 
     add_doctor_action_for_client(portal)
+    ut.addIndexAndColumn('portal_catalog', 'allowedRolesAndUsers', 'FieldIndex')
     ut.addIndex('portal_catalog', 'getPrimaryReferrerUID', 'FieldIndex')
     ut.refreshCatalogs()
+
+    update_permissions_clients(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
 
@@ -62,3 +68,38 @@ def add_doctor_action_for_client(portal):
         description="",
         condition="")
     logger.info("'doctor' action for client portal_type added")
+
+
+def update_permissions_clients(portal):
+    """
+    Maps and updates the permissions for clients.
+
+    :return: None
+    """
+    workflow_tool = api.get_tool("portal_workflow")
+    workflow = workflow_tool.getWorkflowById('bika_doctor_workflow')
+    catalog = api.get_tool('portal_catalog')
+    brains = catalog(portal_type='Doctor')
+    counter = 0
+    total = len(brains)
+    logger.info(
+        "Changing permissions for doctor objects: {0}".format(total))
+    for brain in brains:
+        if 'Client' not in brain.allowedRolesAndUsers:
+            if counter % 100 == 0:
+                logger.info(
+                    "Changing permissions for doctor objects: " +
+                    "{0}/{1}".format(counter, total))
+            obj = api.get_object(brain)
+            workflow.updateRoleMappingsFor(obj)
+            obj.reindexObject()
+        counter += 1
+    logger.info(
+        "Changed permissions for doctor objects: " +
+        "{0}/{1}".format(counter, total))
+    # Allowing client to view clients folder
+    mp = portal.doctors.manage_permission
+    mp(permissions.View,
+       ['Manager', 'LabManager', 'LabClerk', 'LabTechnician',
+        'Doctor', 'Owner', 'Sampler', 'Preserver', 'Client'], 0)
+

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -5,6 +5,8 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+from Products.CMFCore import permissions
+
 from bika.health import logger
 from bika.health.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
@@ -32,6 +34,29 @@ def upgrade(tool):
     setup = portal.portal_setup
     setup.runImportStepFromProfile(profile, "skins")
 
+    add_doctor_action_for_client(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
 
     return True
+
+
+def add_doctor_action_for_client(portal):
+    # Add doctor action for client portal_type programmatically
+    client = portal.portal_types.getTypeInfo("Client")
+    for action in client.listActionInfos():
+        if action.get('id', None) == 'doctors':
+            logger.info("Already existing 'doctor' action for client portal_type")
+            return None
+    client.addAction(
+        id="doctors",
+        name="Doctor",
+        action="string:${object_url}/doctors",
+        permission=permissions.View,
+        category="object",
+        visible=True,
+        icon_expr="string:${portal_url}/images/doctor.png",
+        link_target="",
+        description="",
+        condition="")
+    logger.info("'doctor' action for client portal_type added")

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -93,7 +93,8 @@ def update_permissions_clients(portal, ut):
     logger.info(
         "Changing permissions for doctor objects: {0}".format(total))
     for brain in brains:
-        if 'Client' not in brain.allowedRolesAndUsers:
+        allowed = brain.allowedRolesAndUsers or []
+        if 'Client' not in allowed:
             obj = api.get_object(brain)
             workflow.updateRoleMappingsFor(obj)
             obj.reindexObject()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

- Client contact can create and edit Doctors.
- When a Client contact creates a Doctors, the Doctors is assigned automatically to the same Client the contact belongs to.
- Client contact will only be able to edit Doctors assigned to the same Client as the contact.
- Only Doctors that belong to the same Client as the Client contact will be displayed in Doctors list and selection widgets.

## Current behavior before PR

Client contact has no privileges over doctors

## Desired behavior after PR is merged

Client contact can create and edit Doctors.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
