### PR TITLE
Allow client contacts to list/add/edit Clinical Cases from their own Client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #85 Allow client contact to list/add/edit Batches from its own Client
 - #83 Allow client contact to create and edit Doctors
 
 **Changed**

--- a/bika/health/ajax/configure.zcml
+++ b/bika/health/ajax/configure.zcml
@@ -22,4 +22,12 @@
       layer="bika.lims.interfaces.IBikaLIMS"
     />
 
+    <browser:page
+        for="*"
+        name="ajax-client-from-current-user"
+        class=".client.ajaxGetClientInfoFromCurrentUser"
+        permission="zope.Public"
+        layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
 </configure>

--- a/bika/health/static/js/bika.health.batch.js
+++ b/bika/health/static/js/bika.health.batch.js
@@ -130,6 +130,22 @@ function HealthBatchEditView() {
                 }
             });
         }
+        // Maybe the current user is a client contact. In that case, only the
+        // client the current user belongs to must be available
+        if (refclientuid == null) {
+            $.ajax({
+                url: window.portal_url + "/ajax-client-from-current-user",
+                type: 'POST',
+                async: false,
+                data: {'_authenticator': $('input[name="_authenticator"]').val()},
+                dataType: "json",
+                success: function(data, textStatus, $XHR){
+                    if (data['ClientUID'] != '') {
+                        refclientuid = data['ClientUID'] != '' ? data['ClientUID'] : null;
+                    }
+                }
+            });
+        }
         return refclientuid != '' ? refclientuid : null;
     }
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Client contacts cannot create Clinical Cases (Batches in LIMS). This PR enables client contacts to list, add and edit Clinical Cases (Batches), but only for those that belong to the same Client as the contact.

## Current behavior before PR

Client contact cannot list, add or edit Clinical Cases (Batches)

## Desired behavior after PR is merged

Client contact can list, add or edit Clinical Cases (Batches)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
