### PR TITLE
Traceback accessing Doctor samples when user is not Manager, LabManager or LabClerk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #97 Traceback accessing Doctor samples when user is not Manager, LabManager or LabClerk
 - #82 Inconsistent behavior with health' skins priority over core's
 - #81 Traceback when importing diseases with setupdata.xlsx
 

--- a/bika/health/browser/samples/folder_view.py
+++ b/bika/health/browser/samples/folder_view.py
@@ -87,30 +87,30 @@ class SamplesView(BaseView):
                 for ar in ars:
                     doctor = ar.Schema()['Doctor'].get(ar) if ar else None
                     if doctor and doctor.Title() not in doctors \
-                        and wf.getInfoFor(ar, 'review_state') != 'invalid':
+                            and wf.getInfoFor(ar, 'review_state') != 'invalid':
                         doctors.append(doctor.Title())
                         doctorsanchors.append("<a href='%s'>%s</a>" % (doctor.absolute_url(), doctor.Title()))
-                items[x]['getDoctor'] = ', '.join(doctors);
+                items[x]['getDoctor'] = ', '.join(doctors)
                 items[x]['replace']['getDoctor'] = ', '.join(doctorsanchors)
         return items
 
     def getPatient(self, sample):
-        # Onse sample can have more than one AR associated, but if is
+        # One sample can have more than one AR associated, but if is
         # the case, we must only take into account the one that is not
         # invalidated/retracted
         wf = getToolByName(self.context, 'portal_workflow')
         rawars = sample.getAnalysisRequests()
         target_ar = None
-        ars = [ar for ar in rawars \
+        ars = [ar for ar in rawars
                if (wf.getInfoFor(ar, 'review_state') != 'invalid')]
-        if (len(ars) == 0 and len(rawars) > 0):
+        if len(ars) == 0 and len(rawars) > 0:
             # All ars are invalid. Retrieve the info from the last one
             target_ar = rawars[len(rawars) - 1]
-        elif (len(ars) > 1):
+        elif len(ars) > 1:
             # There's more than one valid AR
             # That couldn't happen never. Anyway, retrieve the last one
             target_ar = ars[len(ars) - 1]
-        elif (len(ars) == 1):
+        elif len(ars) == 1:
             # One ar matches
             target_ar = ars[0]
         if target_ar:

--- a/bika/health/browser/samples/folder_view.py
+++ b/bika/health/browser/samples/folder_view.py
@@ -17,7 +17,6 @@ class SamplesView(BaseView):
 
     def __init__(self, context, request):
         super(SamplesView, self).__init__(context, request)
-
         # Add Patient fields
         self.columns['getPatientID'] = {
             'title': _('Patient ID'),
@@ -49,19 +48,14 @@ class SamplesView(BaseView):
         roles = member.getRoles()
         wf = getToolByName(self.context, 'portal_workflow')
         if 'Manager' not in roles \
-            and 'LabManager' not in roles \
-            and 'LabClerk' not in roles:
+                and 'LabManager' not in roles \
+                and 'LabClerk' not in roles:
             # Remove patient fields. Must be done here because in __init__
             # method, member.getRoles() returns empty
-            del self.columns['getPatientID']
-            del self.columns['getClientPatientID']
-            del self.columns['getPatient']
-            del self.columns['getDoctor']
-            for rs in self.review_states:
-                del rs['columns'][rs['columns'].index('getClientPatientID')]
-                del rs['columns'][rs['columns'].index('getPatientID')]
-                del rs['columns'][rs['columns'].index('getPatient')]
-                del rs['columns'][rs['columns'].index('getDoctor')]
+            self.remove_column('getPatientID')
+            self.remove_column('getClientPatientID')
+            self.remove_column('getPatient')
+            self.remove_column('getDoctor')
         else:
             for x in range(len(items)):
                 if 'obj' not in items[x]:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Steps to reproduce:
* Log in as a user whose roles do not contain `Manager`, `LabManager` or `LabClerk`.
* Navigate to Doctors listing
* Access any doctor
* Go to samples tab 

`KeyError: 'getDoctor'` is raised.

## Current behavior before PR
`KeyError: 'getDoctor'` is raised when accessing Doctor samples with a user that is not a Manager, Lab Manager or Lab Clerk.

### Cause of the error
The problem is that when accessing any doctors samples' list the column `getDoctor` gets removed by default. 

https://github.com/senaite/senaite.health/blob/87049b4fc0894785b45ab5dfcd454e48d5a84855/bika/health/browser/doctor/samples.py#L17-L19

After that the `__call__` method of the parent class (`SamplesView` from [bika.health.browser.samples.folder_view](https://github.com/senaite/senaite.health/blob/87049b4fc0894785b45ab5dfcd454e48d5a84855/bika/health/browser/samples/folder_view.py#L13)) is called and, if the roles of the user do not contain `Manager`, `LabManager` or `LabClerk` then the columns `getPatientID`, `getClientPatientID`, `getPatient` and `getDoctor` are removed without checking if they exist.

https://github.com/senaite/senaite.health/blob/87049b4fc0894785b45ab5dfcd454e48d5a84855/bika/health/browser/samples/folder_view.py#L51-L64

Since `getDoctor` has already been removed a `KeyError` is raised.

## Desired behavior after PR is merged
When accessing Doctor samples with a user that is not a Manager, Lab Manager or Lab Clerk no error is raised and the view is rendered without problems.

To do so, the safe-method `self.remove_column` is used.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
