### PR TITLE
Traceback when publishing health results from inside a client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #99 Traceback when publishing health results from inside a client
 - #82 Inconsistent behavior with health' skins priority over core's
 - #81 Traceback when importing diseases with setupdata.xlsx
 

--- a/bika/health/browser/client/overrides.zcml
+++ b/bika/health/browser/client/overrides.zcml
@@ -36,4 +36,12 @@
       layer="bika.lims.interfaces.IBikaLIMS"
     />
 
+    <browser:page
+      for="bika.lims.interfaces.IClient"
+      name="publish"
+      class="bika.health.browser.analysisrequest.publish.AnalysisRequestPublishView"
+      permission="zope.Public"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #98 

## Current behavior before PR

When publishing a health results report from inside a Client a traceback was raised. The important lines were:
```
AttributeError: 'AnalysisRequestPublishView' object has no attribute 'get_patient'

 - Expression: "       patient         python:v"
 - Filename:   ... lth/browser/analysisrequest/templates/reports/default.pt
 - Location:   (line 21: col 17)
 - Source:     patient         python:view.get_patient(ar_obj);
```
The problem was that the template assumed the view provided the method `get_patient`. However, this method is provided by the class `AnalysisRequestPublishView` defined in `senaite.health` and not in `senaite.core`. 

While some publish actions are being overriden when health add-on is installed:

https://github.com/senaite/senaite.health/blob/87049b4fc0894785b45ab5dfcd454e48d5a84855/bika/health/browser/analysisrequest/overrides.zcml#L39-L45

the client one wasn't.

## Desired behavior after PR is merged

Health results reports are properly rendered when published from inside a client. This is achieved by overriding the client handler for the publish action.

## Screenshot (optional)

![seleccio_033](https://user-images.githubusercontent.com/9968427/43593886-3829b47c-9679-11e8-9f22-285a619f5814.png)




--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
