### PR TITLE
Add button was not displayed in Client's Cases view

### DIFF
--- a/bika/health/browser/client/batches.py
+++ b/bika/health/browser/client/batches.py
@@ -6,17 +6,17 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from Products.CMFCore.utils import getToolByName
+from bika.health import bikaMessageFactory as _
 from bika.lims.browser.client import ClientBatchesView as BaseClientBatchesView
 from bika.health.browser.batch.batchfolder import BatchFolderContentsView as HealthBatchesView
 
 
 class BatchesView(BaseClientBatchesView, HealthBatchesView):
 
-    def contentsMethod(self, contentFilter):
-        batches = {}
-        bc = getToolByName(self.context, "bika_catalog")
-        for batch in bc(portal_type='Batch',
-                        getClientUID = self.context.UID()):
-            batch = batch.getObject()
-            batches[batch.UID()] = batch 
-        return batches.values()
+    def __call__(self):
+        url = self.portal.absolute_url()
+        self.context_actions[_('Add')] = dict(
+            url="{}{}".format(url, "/batches/createObject?type_name=Batch"),
+            icon="{}{}".format(url, "/++resource++bika.lims.images/add.png"))
+
+        return HealthBatchesView.__call__(self)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Add button for adding Clinical Cases was not visible inside Client's Cases view.

## Current behavior before PR

Client contact cannot add  a new Case from it's Client view.

## Desired behavior after PR is merged

Client contact cannot add  a new Case from it's Client view.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
