### PR TITLE
Doctors assigned to other clients are listed when logged as Client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #102 Add Primary Referrer column in Doctor listings
 - #85 Allow client contact to list/add/edit Batches from its own Client
 - #83 Allow client contact to create and edit Doctors
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #102 Doctors assigned to other clients are listed when logged as Client
 - #99 Traceback when publishing health results from inside a client
 - #97 Traceback accessing Doctor samples when user is not Manager, LabManager or LabClerk
 - #82 Inconsistent behavior with health' skins priority over core's

--- a/bika/health/browser/doctors/folder_view.py
+++ b/bika/health/browser/doctors/folder_view.py
@@ -14,7 +14,7 @@ from bika.lims.browser.client import ClientContactsView
 from bika.lims.interfaces import IClient, ILabContact
 from bika.lims.utils import get_link
 from plone.memoize import view as viewcache
-
+from collections import OrderedDict
 
 class DoctorsView(ClientContactsView):
 
@@ -26,31 +26,21 @@ class DoctorsView(ClientContactsView):
         self.title = self.context.translate(_("Doctors"))
         self.icon = self.portal_url + "/++resource++bika.health.images/doctor_big.png"
         self.description = ""
-        self.show_sort_column = False
-        self.show_select_row = False
-        self.show_select_column = False
-        self.pagesize = 50
 
-        self.columns = {
-            'getDoctorID': {'title': _('Doctor ID'),
-                            'index': 'getDoctorID'},
-            'getFullname': {'title': _('Full Name'),
-                            'index': 'getFullname'},
-            'getEmailAddress': {'title': _('Email Address')},
-            'getBusinessPhone': {'title': _('Business Phone')},
-            'getMobilePhone': {'title': _('Mobile Phone')},
-        }
+        # Prepend getDoctorID
+        self.columns = OrderedDict([
+            ("getDoctorID", {
+                "title": _('Doctor ID'),
+                "index": "getDoctorID",
+                "sortable": True, }),
+        ] + self.columns.items())
 
         self.review_states = [
             {'id':'default',
              'title': _('Active'),
              'contentFilter': {'inactive_state': 'active'},
              'transitions': [],
-             'columns': ['getDoctorID',
-                         'getFullname',
-                         'getEmailAddress',
-                         'getBusinessPhone',
-                         'getMobilePhone']},
+             'columns': self.columns.keys()},
         ]
 
     def __call__(self):
@@ -70,21 +60,13 @@ class DoctorsView(ClientContactsView):
                  'title': _('Dormant'),
                  'contentFilter': {'inactive_state': 'inactive'},
                  'transitions': [{'id':'activate'}, ],
-                 'columns': ['getDoctorID',
-                             'getFullname',
-                             'getEmailAddress',
-                             'getBusinessPhone',
-                             'getMobilePhone']})
+                 'columns': self.columns.keys()})
             self.review_states.append(
                 {'id':'all',
                  'title': _('All'),
                  'contentFilter':{},
                  'transitions':[{'id':'empty'}],
-                 'columns': ['getDoctorID',
-                             'getFullname',
-                             'getEmailAddress',
-                             'getBusinessPhone',
-                             'getMobilePhone']})
+                 'columns': self.columns.keys()})
             stat = self.request.get("%s_review_state"%self.form_id, 'default')
             self.show_select_column = stat != 'all'
 

--- a/bika/health/browser/doctors/folder_view.py
+++ b/bika/health/browser/doctors/folder_view.py
@@ -28,13 +28,28 @@ class DoctorsView(ClientContactsView):
         self.icon = self.portal_url + "/++resource++bika.health.images/doctor_big.png"
         self.description = ""
 
-        # Prepend getDoctorID
-        self.columns = OrderedDict([
+        self.columns = OrderedDict((
             ("getDoctorID", {
                 "title": _('Doctor ID'),
                 "index": "getDoctorID",
                 "sortable": True, }),
-        ] + self.columns.items())
+            ("getFullname", {
+                "title": _("Full Name"),
+                "index": "getFullname",
+                "sortable": True, }),
+            ("getPrimaryReferrer", {
+                "title": _("Primary Referrer"),
+                "index": "getPrimaryReferrerUID",
+                "sortable": True, }),
+            ("Username", {
+                "title": _("User Name"), }),
+            ("getEmailAddress", {
+                "title": _("Email Address"), }),
+            ("getBusinessPhone", {
+                "title": _("Business Phone"), }),
+            ("getMobilePhone", {
+                "title": _("MobilePhone"), }),
+        ))
 
         self.review_states = [
             {'id':'default',
@@ -100,4 +115,11 @@ class DoctorsView(ClientContactsView):
         url = item.get("url")
         doctor_id = item.get("getDoctorID")
         item['replace']['getDoctorID'] = get_link(url, value=doctor_id)
+        item['getPrimaryReferrer'] = ""
+        doctor = api.get_object(obj)
+        pri = doctor.getPrimaryReferrer()
+        if pri:
+            pri_url = pri.absolute_url()
+            pri = pri.Title()
+            item['replace']['getPrimaryReferrer'] = get_link(pri_url, value=pri)
         return item

--- a/bika/health/browser/doctors/folder_view.py
+++ b/bika/health/browser/doctors/folder_view.py
@@ -75,6 +75,12 @@ class DoctorsView(ClientContactsView):
             client_uid = api.get_uid(self.context)
             self.contentFilter['getPrimaryReferrerUID'] = client_uid
 
+        # If the current user is a client contact, do not display the doctors
+        # assigned to other clients
+        elif self.get_user_client_uid():
+            client_uid = self.get_user_client_uid()
+            self.contentFilter['getPrimaryReferrerUID'] = [client_uid, None]
+
         return super(DoctorsView, self).__call__()
 
     @viewcache.memoize
@@ -95,26 +101,6 @@ class DoctorsView(ClientContactsView):
             return default
 
         return api.get_uid(client)
-
-    def isItemAllowed(self, obj):
-        """
-        It checks if the item can be added to the list. If the current user is
-        a client contact, only doctors without client assigned or assigned to
-        sime client as the contact will be displayed.
-        """
-        allowed = super(DoctorsView, self).isItemAllowed(obj)
-        if not allowed:
-            return False
-
-        # Current user belongs to a client
-        client_uid = self.get_user_client_uid()
-        if not client_uid:
-            return True
-
-        # Only visible if the Doctor has the same client assigned or None
-        referrer_uid = api.get_object(obj).getPrimaryReferrerUID()
-        return not referrer_uid or referrer_uid == client_uid
-
 
     def folderitem(self, obj, item, index):
         """Applies new properties to the item to be rendered

--- a/bika/health/browser/doctors/folder_view.py
+++ b/bika/health/browser/doctors/folder_view.py
@@ -5,16 +5,17 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.CMFCore.utils import getToolByName
+from collections import OrderedDict
 
+from Products.CMFCore.utils import getToolByName
 from bika.health import bikaMessageFactory as _
 from bika.health.permissions import *
 from bika.lims import api
 from bika.lims.browser.client import ClientContactsView
-from bika.lims.interfaces import IClient, ILabContact
+from bika.lims.interfaces import IClient
 from bika.lims.utils import get_link
 from plone.memoize import view as viewcache
-from collections import OrderedDict
+
 
 class DoctorsView(ClientContactsView):
 
@@ -87,20 +88,10 @@ class DoctorsView(ClientContactsView):
     def get_user_client_uid(self, default=None):
         """Returns the id of the client the current user belongs to
         """
-        user = api.get_current_user()
-        roles = user.getRoles()
-        if 'Client' not in roles:
-            return default
-
-        contact = api.get_user_contact(user)
-        if not contact or ILabContact.providedBy(contact):
-            return default
-
-        client = api.get_parent(contact)
-        if not client or not IClient.providedBy(client):
-            return default
-
-        return api.get_uid(client)
+        client = api.get_current_client()
+        if client:
+            return api.get_uid(client)
+        return default
 
     def folderitem(self, obj, item, index):
         """Applies new properties to the item to be rendered

--- a/bika/health/browser/doctors/folder_view.py
+++ b/bika/health/browser/doctors/folder_view.py
@@ -12,6 +12,7 @@ from bika.health.permissions import *
 from bika.lims import api
 from bika.lims.browser.client import ClientContactsView
 from bika.lims.interfaces import IClient, ILabContact
+from bika.lims.utils import get_link
 from plone.memoize import view as viewcache
 
 
@@ -132,15 +133,12 @@ class DoctorsView(ClientContactsView):
         referrer_uid = api.get_object(obj).getPrimaryReferrerUID()
         return not referrer_uid or referrer_uid == client_uid
 
-    def folderitems(self):
-        items = super(DoctorsView, self).folderitems()
-        for x in range(len(items)):
-            if not 'obj' in items[x]:
-                continue
-            obj = items[x]['obj']
-            items[x]['replace']['getDoctorID'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['getDoctorID'])
-            items[x]['replace']['getFullname'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['getFullname'])
 
-        return items
+    def folderitem(self, obj, item, index):
+        """Applies new properties to the item to be rendered
+        """
+        item = super(DoctorsView, self).folderitem(obj, item, index)
+        url = item.get("url")
+        doctor_id = item.get("getDoctorID")
+        item['replace']['getDoctorID'] = get_link(url, value=doctor_id)
+        return item

--- a/bika/health/static/js/bika.health.analysisrequest.add.js
+++ b/bika/health/static/js/bika.health.analysisrequest.add.js
@@ -298,6 +298,12 @@ function HealthAnalysisRequestAddView() {
             if (element.length > 0) {
                 filter_combogrid(element[0], "getParentUID", clientuid);
             }
+
+            // Doctor searches
+            element = $("#Doctor-" + col);
+            if (element.length > 0) {
+                filter_combogrid(element[0], "getPrimaryReferrerUID", [clientuid, null]);
+            }
         }
     }
 

--- a/bika/health/static/js/bika.health.batch.js
+++ b/bika/health/static/js/bika.health.batch.js
@@ -202,6 +202,8 @@ function HealthBatchEditView() {
             // client inside patient-related combos
             applyFilter($("#Patient"), 'getPrimaryReferrerUID', rcuid);
             applyFilter($("#ClientPatientID"), 'getPrimaryReferrerUID', rcuid);
+            // Also, show only the Doctors that are not from a different client
+            applyFilter($("#Doctor"), 'getPrimaryReferrerUID', [rcuid, null]);
         }
 
         // By default, get the referrer uids from the form itself. If the form is


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

If the current user is a Client contact, only the doctors assigned to the same client and those that do not have any client assigned are displayed. If user is from the lab, no filtering is applied.

If the current context of the listing is Client, only doctors assigned to same client are displayed.

Dependencies:
- https://github.com/senaite/senaite.core/pull/1014 
- https://github.com/senaite/senaite.core/pull/1013
- https://github.com/senaite/senaite.core/pull/1012

## Current behavior before PR

All doctors are displayed in Doctors listing when logged in as client contact

## Desired behavior after PR is merged

Doctors not assigned to the same client as the user logged in are not displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
