### PR TITLE
All Samples are listed inside Case context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Changelog
 
 **Fixed**
 
-- #102 Link to Add Case inside client context is wrong
+- #102 All Samples are listed inside Case context
 - #99 Traceback when publishing health results from inside a client
 - #97 Traceback accessing Doctor samples when user is not Manager, LabManager or LabClerk
 - #82 Inconsistent behavior with health' skins priority over core's

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #102 Link to Add Case inside client context is wrong
 - #99 Traceback when publishing health results from inside a client
 - #97 Traceback accessing Doctor samples when user is not Manager, LabManager or LabClerk
 - #82 Inconsistent behavior with health' skins priority over core's

--- a/bika/health/browser/batch/samples.py
+++ b/bika/health/browser/batch/samples.py
@@ -5,28 +5,17 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.CMFCore.utils import getToolByName
+from bika.lims import api
 from bika.health.browser.samples.folder_view import SamplesView
 
 
 class BatchSamplesView(SamplesView):
+
     def __init__(self, context, request):
         super(BatchSamplesView, self).__init__(context, request)
         self.view_url = self.context.absolute_url() + "/samples"
-        if 'path' in self.contentFilter:
-            del(self.contentFilter['path'])
-
-    def contentsMethod(self, contentFilter):
-        tool = getToolByName(self.context, self.catalog)
-        state = [x for x in self.review_states if x['id'] == self.review_state['id']][0]
-        for k, v in state['contentFilter'].items():
-            self.contentFilter[k] = v
-        tool_samples = tool(contentFilter)
-        samples = {}
-        for sample in (p.getObject() for p in tool_samples):
-            for ar in sample.getAnalysisRequests():
-                batch = ar.getBatch()
-                batch_uid = batch.UID() if batch else ''
-                if batch_uid == self.context.UID():
-                    samples[sample.getId()] = sample
-        return samples.values()
+        self.contentFilter = {'portal_type': 'Sample',
+                              'getBatchUIDs': api.get_uid(self.context),
+                              'sort_on': 'created',
+                              'sort_order': 'reverse',
+                              'cancellation_state':'active'}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Only the Samples from a Case must be listed inside Case context

## Current behavior before PR

All Samples are listed inside Case context.

## Desired behavior after PR is merged

Only Samples from the Case are listed inside Case context.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
