### PR TITLE
Do not allow to change the Client from Doctor if has batches or ARs assigned

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 **Added**
 
 - #85 Allow client contact to list/add/edit Batches from its own Client
+- #102 Add Primary Referrer column in Doctor listings
+- #85 Allow client contact to list/add/edit Cases from its own Client
 - #83 Allow client contact to create and edit Doctors
 
 **Changed**

--- a/bika/health/content/doctor.py
+++ b/bika/health/content/doctor.py
@@ -85,8 +85,16 @@ class Doctor(Contact):
         if primary_referrer:
             return primary_referrer.UID()
 
-
-# schemata.finalizeATCTSchema(schema, folderish=True, moveDiscussion=False)
-
+    def current_user_can_edit(self):
+        """Returns true if the current user can edit this Doctor.
+        """
+        user_client = api.get_current_client()
+        if user_client:
+            # The current user is a client contact. This user can only edit
+            # this doctor if it has the same client assigned
+            client_uid = api.get_uid(user_client)
+            doctor_client = self.getPrimaryReferrer()
+            return doctor_client and api.get_uid(doctor_client) == client_uid
+        return True
 
 atapi.registerType(Doctor, PROJECTNAME)

--- a/bika/health/profiles/default/types/Doctor.xml
+++ b/bika/health/profiles/default/types/Doctor.xml
@@ -17,7 +17,7 @@
  <property name="allow_discussion">False</property>
  <property name="default_view_fallback">False</property>
 
- <alias from="(Default)" to="base_edit"/>
+ <alias from="(Default)" to="analysisrequests"/>
  <alias from="view" to="base_edit"/>
  <alias from="edit" to="base_edit"/>
 
@@ -35,12 +35,12 @@
  <action title="Edit"
          action_id="edit"
          category="object"
-         condition_expr=""
+         condition_expr="python:object.current_user_can_edit()"
          url_expr="string:${object_url}/edit"
          i18n:attributes="title"
          i18n:domain="plone"
          visible="True">
-    <permission value="BIKA: Manage Bika"/>
+    <permission value="Modify portal content"/>
  </action>
 
  <action title="Analysis Requests"

--- a/bika/health/upgrade/v01_01_003.py
+++ b/bika/health/upgrade/v01_01_003.py
@@ -38,6 +38,7 @@ def upgrade(tool):
     setup = portal.portal_setup
     setup.runImportStepFromProfile(profile, "skins")
     setup.runImportStepFromProfile(profile, 'workflow')
+    setup.runImportStepFromProfile(profile, "typeinfo")
 
     # Allow client contacts to list, add and edit batches (cases)
     apply_batch_permissions_for_clients(portal)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request contains the following:

- Display Edit tab in doctor only if current user can edit
  Doctors can only be edited by a client contact if the doctor has the same client assigned.

- Do not allow to change client in Doctor if ARs or Batches
  If the current logged in user is from lab personnel, load the clients as usual, but only if the Doctor does not have any Analysis Request or Batch assigned. Otherwise, don't allow to change the Client.
  If the user is a client and the Doctor has a client already set, do not allow to change the primary client.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
