### PR TITLE
DateTime validator fires even if DateOfBirth is non-mandatory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog
 
 **Fixed**
 
+- #107 DateTime validator fires even if DateOfBirth is non-mandatory
 - #106 Fields from Patient's additional tabs are not displayed
 - #105 Date of Birth and Age are required fields for anonymous patients
 - #102 Doctors assigned to other clients are listed when logged as Client

--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -25,7 +25,11 @@ class Date_Format_Validator:
     name = "isDateFormat"
 
     def __call__(self, value, *args, **kwargs):
-        instance = kwargs['instance']
+        field = kwargs.get('field', None)
+        required = hasattr(field, "required") and field.required or False
+        if not value and not required:
+            return True
+
         try:
             datetime.strptime(value, '%Y-%m-%d')
         except ValueError:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Make the DateTime validator to be field-required aware.

## Current behavior before PR

Even if Date of Birth field is set to `required=False`, the field validator rises the error `Incorrect data format in '', should be YYYY-MM-DD`.

## Desired behavior after PR is merged

If a DateTime field is set as non-required, the field validator will not rise the error when the value is empty.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
