### PR TITLE
Autodetect suitable client in Doctor's edit view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog
 
 **Fixed**
 
+- #108 Autodetect suitable client in Doctor's edit view
 - #107 DateTime validator fires even if DateOfBirth is non-mandatory
 - #106 Fields from Patient's additional tabs are not displayed
 - #105 Date of Birth and Age are required fields for anonymous patients

--- a/bika/health/content/doctor.py
+++ b/bika/health/content/doctor.py
@@ -94,7 +94,24 @@ class Doctor(Contact):
             # Allow to change the client if there are no ARs associated
             client = self.getPrimaryReferrer()
             if not client:
-                return DisplayList([('', '')])
+                # Maybe all Batches and ARs assigned to this Doctor belong to
+                # the same Client.. If so, just assign this client by default
+                client_uids = map(lambda ar: ar.getClientUID,
+                                  self.getAnalysisRequests())
+                client_uids = list(set(client_uids))
+                if len(client_uids) > 1:
+                    # More than one client assigned!
+                    return DisplayList([('', '')])
+                clients = map(lambda batch: batch.getClient(),
+                              self.getBatches(full_objects=True))
+                client_uids += map(lambda client: api.get_uid(client), clients)
+                client_uids = list(set(client_uids))
+                if len(client_uids) > 1:
+                    # More than one client assigned!
+                    return DisplayList([('', '')])
+
+                client = api.get_object_by_uid(client_uids[0])
+
             return DisplayList([(api.get_uid(client), client.Title())])
 
         # If the current user is a client contact, do not display other clients


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this Pull Request, the selection list of Clients inside Doctor's edit view gets populated with suitable client when Doctor has no client assigned, but is associated to Analysis Requests or Batches.

If all Analysis Requests and Batches associated to the Doctor are assigned to the same Client, the list displays only that client for selection. Otherwise, do not allow to choose any client.

## Current behavior before PR

There is no possibility to assign a Doctor to a Client if the Doctor has no client previously assigned and is associated to Batches and/or Analysis Requests.

## Desired behavior after PR is merged

Possibility to assign a Doctor to a Client if the Doctor has no previously assigned any Client, but is associated to Analysis Requests and/or Batches that all them belong to the same Client.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
