### PR TITLE
Fix Traceback "bika_widgets/remarks does not exist for ..."

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog
 
 **Fixed**
 
+- #109 Traceback `bika_widgets/remarks does not exist for`
 - #107 DateTime validator fires even if DateOfBirth is non-mandatory
 - #106 Fields from Patient's additional tabs are not displayed
 - #105 Date of Birth and Age are required fields for anonymous patients

--- a/bika/health/content/insurancecompany.py
+++ b/bika/health/content/insurancecompany.py
@@ -9,20 +9,18 @@ from AccessControl import ClassSecurityInfo
 from Products.Archetypes.public import *
 from bika.health import bikaMessageFactory as _
 from bika.health.config import PROJECTNAME
-from bika.lims.content.organisation import Organisation
 from bika.health.interfaces import IInsuranceCompany
+from bika.lims.browser.fields.remarksfield import RemarksField
+from bika.lims.browser.widgets.remarkswidget import RemarksWidget
+from bika.lims.content.organisation import Organisation
 from zope.interface import implements
 
 schema = Organisation.schema.copy() + ManagedSchema((
-    TextField('Remarks',
+    RemarksField(
+        'Remarks',
         searchable = True,
-        default_content_type = 'text/x-web-intelligent',
-        allowable_content_types = ('text/x-web-intelligent',),
-        default_output_type = "text/html",
-        widget = TextAreaWidget(
-            macro = "bika_widgets/remarks",
+        widget = RemarksWidget(
             label = _('Remarks'),
-            append_only = True,
         ),
     ),
 ))

--- a/bika/health/content/patient.py
+++ b/bika/health/content/patient.py
@@ -17,11 +17,13 @@ from bika.lims import bikaMessageFactory as _b
 from bika.health import bikaMessageFactory as _
 from bika.lims.browser.fields import AddressField
 from bika.lims.browser.fields import DateTimeField as DateTimeField_bl
+from bika.lims.browser.fields.remarksfield import RemarksField
 from bika.lims.browser.widgets import AddressWidget
 from bika.lims.browser.widgets import DateTimeWidget as DateTimeWidget_bl
 from bika.lims.browser.widgets import RecordsWidget
 from bika.health.widgets import SplittedDateWidget
 from bika.health.config import *
+from bika.lims.browser.widgets.remarkswidget import RemarksWidget
 from bika.lims.content.person import Person
 from bika.health.interfaces import IPatient
 from bika.health.permissions import *
@@ -187,16 +189,11 @@ schema = Person.schema.copy() + Schema((
             visible=False
         ),
     ),
-    TextField(
+    RemarksField(
         'Remarks',
         searchable=True,
-        default_content_type='text/plain',
-        allowable_content_types=('text/plain', ),
-        default_output_type="text/plain",
-        widget=TextAreaWidget(
-            macro="bika_widgets/remarks",
+        widget=RemarksWidget(
             label=_('Remarks'),
-            append_only=True,
         ),
     ),
     RecordsField(

--- a/bika/health/content/vaccinationcenter.py
+++ b/bika/health/content/vaccinationcenter.py
@@ -11,20 +11,18 @@ from Products.Archetypes.utils import DisplayList
 from bika.lims import bikaMessageFactory as _b
 from bika.health import bikaMessageFactory as _
 from bika.health.config import PROJECTNAME
+from bika.lims.browser.fields.remarksfield import RemarksField
+from bika.lims.browser.widgets.remarkswidget import RemarksWidget
 from bika.lims.content.organisation import Organisation
 from bika.health.interfaces import IVaccinationCenter
 from zope.interface import implements
 
 schema = Organisation.schema.copy() + ManagedSchema((
-    TextField('Remarks',
+    RemarksField(
+        'Remarks',
         searchable = True,
-        default_content_type = 'text/x-web-intelligent',
-        allowable_content_types = ('text/x-web-intelligent',),
-        default_output_type = "text/html",
-        widget = TextAreaWidget(
-            macro = "bika_widgets/remarks",
+        widget = RemarksWidget(
             label = _('Remarks'),
-            append_only = True,
         ),
     ),
 ))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`bika_widgets/remarks` is no longer available in `senaite.core` because of https://github.com/senaite/senaite.core/pull/920 This pull request makes `senaite.health` compatible with `senaite.core` v1.2.8

Linked issue: https://github.com/senaite/senaite.health/issues/100

## Current behavior before PR

The following Traceback when editing Patient, Insurance Company or Vaccination Center:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFPlone.FactoryTool, line 478, in __call__
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 91, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 32, in _call
  Module Shared.DC.Scripts.Bindings, line 322, in __call__
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module Products.CMFCore.FSPageTemplate, line 237, in _exec
  Module Products.CMFCore.FSPageTemplate, line 177, in pt_render
  Module Products.PageTemplates.PageTemplate, line 87, in pt_render
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 158, in render
  Module chameleon.zpt.template, line 297, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 338b44bf2274717b61b2323795a9c98f.py, line 1101, in render
  Module 338b44bf2274717b61b2323795a9c98f.py, line 911, in render_master
  Module 69e91da7ad509eec74265fa5c1df1777.py, line 1465, in render_master
  Module 69e91da7ad509eec74265fa5c1df1777.py, line 645, in render_content
  Module 338b44bf2274717b61b2323795a9c98f.py, line 901, in __fill_main
  Module 338b44bf2274717b61b2323795a9c98f.py, line 153, in render_main
  Module 5f0aa4601784b64af4844c8766340a88.py, line 414, in render_body
  Module Products.Archetypes.BaseObject, line 276, in widget
  Module Products.Archetypes.Renderer, line 26, in render
  Module Products.Archetypes.generator.widget, line 147, in __call__
AttributeError: Macro bika_widgets/remarks does not exist for <Patient at patient.2018-09-17.1793646232>
```

## Desired behavior after PR is merged

No errors. The user can edit without problems.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
