### PR TITLE
Fix ValueError on install: The object with the id "invoices" does not exist

### DIFF
--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -219,9 +219,6 @@ def setup_site_structure(context):
         obj.unmarkCreationFlag()
         obj.reindexObject()
 
-    # Resort Invoices and AR Invoice (HEALTH-215) in navigation
-    portal.moveObjectToPosition('invoices', portal.objectIds().index('supplyorders'))
-    portal.moveObjectToPosition('arimports', portal.objectIds().index('referencesamples'))
     logger.info("Setup site structure [DONE]")
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Invoices and ARImports links are not longer visible in navigation bar due to https://github.com/senaite/senaite.core/pull/1304

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module <string>, line 3, in installProducts
  Module AccessControl.requestmethod, line 70, in _curried
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 683, in installProducts
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 599, in installProduct
  Module Products.GenericSetup.tool, line 1442, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1289, in _doRunHandler
  Module bika.health.setuphandlers, line 92, in post_install
  Module bika.health.setuphandlers, line 223, in setup_site_structure
  Module OFS.OrderSupport, line 224, in moveObjectToPosition
  Module OFS.OrderSupport, line 219, in getObjectPosition
ValueError: The object with the id "invoices" does not exist.
```

## Desired behavior after PR is merged

No traceback. `senaite.health` gets installed correctly.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
