### PR TITLE
Filtering patient listing is slow

### DIFF
--- a/bika/health/catalog/indexers/configure.zcml
+++ b/bika/health/catalog/indexers/configure.zcml
@@ -15,7 +15,6 @@
   <!-- Patients catalog -->
   <adapter name="client_uid" factory=".patient.client_uid"/>
   <adapter name="client_assigned" factory=".patient.client_assigned"/>
-  <adapter name="searchable_text" factory=".patient.searchable_text"/>
-
+  <adapter name="listing_searchable_text" factory=".patient.listing_searchable_text"/>
 
 </configure>

--- a/bika/health/catalog/patient_catalog.py
+++ b/bika/health/catalog/patient_catalog.py
@@ -41,7 +41,7 @@ CATALOG_INDEXES = {
     "getPatientID": "FieldIndex",
     # TODO Remove in favour of client_uid
     "getPrimaryReferrerUID": "FieldIndex",
-    "searchable_text": "TextIndexNG3",
+    "listing_searchable_text": "TextIndexNG3",
 }
 
 CATALOG_COLUMNS = [

--- a/bika/health/content/analysisrequest.py
+++ b/bika/health/content/analysisrequest.py
@@ -83,7 +83,7 @@ class AnalysisRequestSchemaExtender(object):
                 visible={'add': 'edit',
                          'secondary': 'disabled'},
                 catalog_name='bikahealth_catalog_patient_listing',
-                search_fields=('searchable_text',),
+                search_fields=('listing_searchable_text',),
                 base_query={'is_active': True,
                             'sort_limit': 50,
                             'sort_on': 'getPatientID',

--- a/bika/health/content/batch.py
+++ b/bika/health/content/batch.py
@@ -223,7 +223,7 @@ class BatchSchemaExtender(object):
                 visible={'edit': 'visible',
                          'view': 'visible'},
                 catalog_name='bikahealth_catalog_patient_listing',
-                search_fields=('searchable_text',),
+                search_fields=('listing_searchable_text',),
                 base_query={'is_active': True,
                             'sort_limit': 50,
                             'sort_on': 'getPatientID',

--- a/bika/health/upgrade/v01_02_000.py
+++ b/bika/health/upgrade/v01_02_000.py
@@ -42,7 +42,7 @@ INDEXES = [
     # Tuples of (catalog, index_name, index_type)
     (CATALOG_PATIENTS, "client_assigned", "BooleanIndex"),
     (CATALOG_PATIENTS, "client_uid", "FieldIndex"),
-    (CATALOG_PATIENTS, "searchable_text", "TextIndexNG3")
+    (CATALOG_PATIENTS, "listing_searchable_text", "TextIndexNG3")
 ]
 
 COLUMNS = [
@@ -53,7 +53,7 @@ INDEXES_TO_DELETE = [
     # Tuples of (catalog, index_name)
     (CATALOG_PATIENTS, "getPatientIdentifiers"),
     (CATALOG_PATIENTS, "inactive_state"),
-    (CATALOG_PATIENTS, "listing_searchable_text")
+    (CATALOG_PATIENTS, "searchable_text")
 ]
 
 COLUMNS_TO_DELETE = [
@@ -84,9 +84,9 @@ def upgrade(tool):
                                                    version))
 
     # -------- ADD YOUR STUFF BELOW --------
-    setup.runImportStepFromProfile(profile, "browserlayer")
-    setup.runImportStepFromProfile(profile, "typeinfo")
-    setup.runImportStepFromProfile(profile, "skins")
+    #setup.runImportStepFromProfile(profile, "browserlayer")
+    #setup.runImportStepFromProfile(profile, "typeinfo")
+    #setup.runImportStepFromProfile(profile, "skins")
 
     # Setup catalogs
     setup_catalogs(CATALOGS_BY_TYPE, INDEXES, COLUMNS)
@@ -95,28 +95,28 @@ def upgrade(tool):
     remove_indexes_and_metadata()
 
     # Setup permissions
-    setup_roles_permissions(portal)
+    #setup_roles_permissions(portal)
 
     # Setup ID Formatting
-    setup_id_formatting(portal)
+    #setup_id_formatting(portal)
 
     # Add "Patients" and "Doctors" action views in Client type
-    setup_content_actions(portal)
+    #setup_content_actions(portal)
 
     # Remove "Samples" action views from Doctors and Patients
-    remove_sample_actions(portal)
+    #remove_sample_actions(portal)
 
     # Setup "Owner" roles for patients to client contacts
-    setup_patients_ownership(portal)
+    #setup_patients_ownership(portal)
 
     # Setup "Owner" roles for batches to client contacts
-    setup_batches_ownership(portal)
+    #setup_batches_ownership(portal)
 
     # Update workflows
-    update_workflows(portal)
+    #update_workflows(portal)
 
     # remove stale CSS
-    remove_stale_css(portal)
+    #remove_stale_css(portal)
 
     logger.info("{0} upgraded to version {1}".format(PROJECTNAME, version))
     return True

--- a/bika/health/upgrade/v01_02_000.py
+++ b/bika/health/upgrade/v01_02_000.py
@@ -84,9 +84,9 @@ def upgrade(tool):
                                                    version))
 
     # -------- ADD YOUR STUFF BELOW --------
-    #setup.runImportStepFromProfile(profile, "browserlayer")
-    #setup.runImportStepFromProfile(profile, "typeinfo")
-    #setup.runImportStepFromProfile(profile, "skins")
+    setup.runImportStepFromProfile(profile, "browserlayer")
+    setup.runImportStepFromProfile(profile, "typeinfo")
+    setup.runImportStepFromProfile(profile, "skins")
 
     # Setup catalogs
     setup_catalogs(CATALOGS_BY_TYPE, INDEXES, COLUMNS)
@@ -95,28 +95,28 @@ def upgrade(tool):
     remove_indexes_and_metadata()
 
     # Setup permissions
-    #setup_roles_permissions(portal)
+    setup_roles_permissions(portal)
 
     # Setup ID Formatting
-    #setup_id_formatting(portal)
+    setup_id_formatting(portal)
 
     # Add "Patients" and "Doctors" action views in Client type
-    #setup_content_actions(portal)
+    setup_content_actions(portal)
 
     # Remove "Samples" action views from Doctors and Patients
-    #remove_sample_actions(portal)
+    remove_sample_actions(portal)
 
     # Setup "Owner" roles for patients to client contacts
-    #setup_patients_ownership(portal)
+    setup_patients_ownership(portal)
 
     # Setup "Owner" roles for batches to client contacts
-    #setup_batches_ownership(portal)
+    setup_batches_ownership(portal)
 
     # Update workflows
-    #update_workflows(portal)
+    update_workflows(portal)
 
     # remove stale CSS
-    #remove_stale_css(portal)
+    remove_stale_css(portal)
 
     logger.info("{0} upgraded to version {1}".format(PROJECTNAME, version))
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://github.com/senaite/senaite.health/issues/121

`SearchableText` index has been replaced by `listing_searchable_text` that is used the default indexes for searches in `senaite.core.listing`. If this index  is not found `senaite.core.listing` does a "manual" search.

## Current behavior before PR

Searches in patient listing are slow

## Desired behavior after PR is merged

Searches in patient listing are fast

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
