### PR TITLE
Autofill fields from Add Sample depending on the context

### DIFF
--- a/bika/health/adapters/addsample.py
+++ b/bika/health/adapters/addsample.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.HEALTH.
+#
+# SENAITE.HEALTH is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2019 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.health.interfaces import IDoctor, IPatient
+from bika.lims import api
+from bika.lims.interfaces import IGetDefaultFieldValueARAddHook, IClient
+from zope.component import adapts
+
+
+class AddFormFieldDefaultValueAdapter(object):
+    """Generic adapter for objects retrieval based on request uid and field name
+    """
+
+    def __init__(self, request):
+        self.request = request
+
+    def get_object_from_request_field(self, field_name):
+        """Returns the object for the field_name specified in the request
+        """
+        uid = self.request.get(field_name)
+        return api.get_object_by_uid(uid, default=None)
+
+
+
+class ClientDefaultFieldValue(AddFormFieldDefaultValueAdapter):
+    """Adapter that returns the default value for field Client in Sample form
+    """
+
+    adapts(IGetDefaultFieldValueARAddHook)
+
+
+    def __call__(self, context):
+
+        if IClient.providedBy(context):
+            return context
+
+        # Try with client object explicitly defined in request
+        client = self.get_object_from_request_field("Client")
+        if client:
+            return client
+
+        # Try to get the client from selected Patient
+        patient = PatientDefaultFieldValue(self.request)(context)
+        client = patient and patient.getPrimaryReferrer() or None
+        if client:
+            return client
+
+        # Try to get the client from selected Doctor
+        doctor = DoctorDefaultFieldValue(self.request)(context)
+        client = doctor and doctor.getPrimaryReferrer() or None
+        if client:
+            return client
+
+        return None
+
+
+
+class PatientDefaultFieldValue(AddFormFieldDefaultValueAdapter):
+    """Adapter that returns the default value for field Patien in Sample form
+    """
+    adapts(IGetDefaultFieldValueARAddHook)
+
+    def __call__(self, context):
+        if IPatient.providedBy(context):
+            return context
+
+        # Try with doctor explicitly defined in request
+        return self.get_object_from_request_field("Patient")
+
+
+
+class DoctorDefaultFieldValue(AddFormFieldDefaultValueAdapter):
+    """Adapter that returns the default value for field Doctor in Sample form
+    """
+    adapts(IGetDefaultFieldValueARAddHook)
+
+
+    def __call__(self, context):
+        if IDoctor.providedBy(context):
+            return context
+
+        # Try with doctor explicitly defined in request
+        return self.get_object_from_request_field("Doctor")

--- a/bika/health/adapters/configure.zcml
+++ b/bika/health/adapters/configure.zcml
@@ -9,4 +9,28 @@
       name="PatientFieldsVisibility"
     />
 
+    <!-- Default value for Client field in Add Sample form -->
+    <adapter
+      factory=".addsample.ClientDefaultFieldValue"
+      for="*"
+      provides="bika.lims.interfaces.IGetDefaultFieldValueARAddHook"
+      name = "Client_default_value_hook"
+    />
+
+    <!-- Default value for Patient field in Add Sample form -->
+    <adapter
+      factory=".addsample.PatientDefaultFieldValue"
+      for="*"
+      provides="bika.lims.interfaces.IGetDefaultFieldValueARAddHook"
+      name = "Patient_default_value_hook"
+    />
+
+    <!-- Default value for Doctor field in Add Sample form -->
+    <adapter
+      factory=".addsample.DoctorDefaultFieldValue"
+      for="*"
+      provides="bika.lims.interfaces.IGetDefaultFieldValueARAddHook"
+      name = "Doctor_default_value_hook"
+    />
+
 </configure>

--- a/bika/health/browser/doctor/analysisrequests.py
+++ b/bika/health/browser/doctor/analysisrequests.py
@@ -18,10 +18,34 @@
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from bika.health.browser.analysisrequests.view import AnalysisRequestsView as BaseView
+from bika.health.browser.analysisrequests.view import \
+    AnalysisRequestsView as BaseView
+from bika.lims import api
+from bika.lims.browser import BrowserView
 
 
 class AnalysisRequestsView(BaseView):
+
     def __init__(self, context, request):
         super(AnalysisRequestsView, self).__init__(context, request)
         self.contentFilter['getDoctorUID'] = self.context.UID()
+
+
+
+class AnalysisRequestAddRedirectView(BrowserView):
+    """Artifact to redirect the user to AR Add view when 'AR Add' button is
+    clicked in Doctor's Analysis Requests view
+    """
+
+    def __call__(self):
+        base_folder = self.context.getPrimaryReferrer()
+        if not base_folder:
+            # Doctor w/o client assigned, just use analysisrequests folder
+            base_folder = api.get_portal().analysisrequests
+
+        url = "{}/{}".format(api.get_url(base_folder), "ar_add")
+        url = "{}?Doctor={}".format(url, api.get_uid(self.context))
+        qs = self.request.getHeader("query_string")
+        if qs:
+            url = "{}&{}".format(url, qs)
+        return self.request.response.redirect(url)

--- a/bika/health/browser/doctor/configure.zcml
+++ b/bika/health/browser/doctor/configure.zcml
@@ -1,31 +1,39 @@
 <configure
-    xmlns="http://namespaces.zope.org/zope"
-    xmlns:browser="http://namespaces.zope.org/browser"
-    xmlns:i18n="http://namespaces.zope.org/i18n"
-    i18n_domain="senaite.health">
+  xmlns="http://namespaces.zope.org/zope"
+  xmlns:browser="http://namespaces.zope.org/browser"
+  i18n_domain="senaite.health">
 
-    <browser:page
-      for="bika.health.interfaces.IDoctor"
-      name="analysisrequests"
-      class=".analysisrequests.AnalysisRequestsView"
-      permission="zope2.View"
-      layer="bika.health.interfaces.IBikaHealth"
-    />
+  <browser:page
+    for="bika.health.interfaces.IDoctor"
+    name="analysisrequests"
+    class=".analysisrequests.AnalysisRequestsView"
+    permission="zope2.View"
+    layer="bika.health.interfaces.IBikaHealth"
+  />
 
-    <browser:page
-      for="*"
-      name="getDoctorID"
-      class=".getdoctorid.ajaxGetDoctorID"
-      permission="zope2.View"
-      layer="bika.health.interfaces.IBikaHealth"
-    />
-    
-    <browser:page
-      for="*"
-      name="getdoctorinfo"
-      class=".getdoctorinfo.ajaxGetDoctorInfo"
-      permission="zope2.View"
-      layer="bika.health.interfaces.IBikaHealth"
-    />
+  <browser:page
+    for="*"
+    name="getDoctorID"
+    class=".getdoctorid.ajaxGetDoctorID"
+    permission="zope2.View"
+    layer="bika.health.interfaces.IBikaHealth"
+  />
+
+  <browser:page
+    for="*"
+    name="getdoctorinfo"
+    class=".getdoctorinfo.ajaxGetDoctorInfo"
+    permission="zope2.View"
+    layer="bika.health.interfaces.IBikaHealth"
+  />
+
+  <!-- Redirect to Client AR Add view when "AR Add" clicked inside Doctor -->
+  <browser:page
+    for="bika.health.interfaces.IDoctor"
+    name="ar_add"
+    class=".analysisrequests.AnalysisRequestAddRedirectView"
+    permission="senaite.core.permissions.AddAnalysisRequest"
+    layer="bika.lims.interfaces.IBikaLIMS"
+  />
 
 </configure>

--- a/bika/health/browser/patient/analysisrequests.py
+++ b/bika/health/browser/patient/analysisrequests.py
@@ -39,10 +39,14 @@ class AnalysisRequestAddRedirectView(BrowserView):
     """
 
     def __call__(self):
-        client = self.context.getPrimaryReferrer()
-        url = "{}/{}".format(api.get_url(client), "ar_add")
+        base_folder = self.context.getPrimaryReferrer()
+        if not base_folder:
+            # Doctor w/o client assigned, just use analysisrequests folder
+            base_folder = api.get_portal().analysisrequests
+
+        url = "{}/{}".format(api.get_url(base_folder), "ar_add")
+        url = "{}?Patient={}".format(url, api.get_uid(self.context))
         qs = self.request.getHeader("query_string")
         if qs:
-            url = "{}?{}".format(url, qs)
-        self.request.response.redirect(url)
-        return
+            url = "{}&{}".format(url, qs)
+        return self.request.response.redirect(url)

--- a/bika/health/browser/patient/configure.zcml
+++ b/bika/health/browser/patient/configure.zcml
@@ -101,13 +101,13 @@
       layer="bika.health.interfaces.IBikaHealth"
     />
 
-    <!-- Redirect to Client AR Add view when "AR Add" clicked inside Patient -->
-    <browser:page
-      for="bika.health.interfaces.IPatient"
-      name="ar_add"
-      class=".analysisrequests.AnalysisRequestAddRedirectView"
-      permission="senaite.core.permissions.AddAnalysisRequest"
-      layer="bika.lims.interfaces.IBikaLIMS"
-    />
+  <!-- Redirect to Client AR Add view when "AR Add" clicked inside Patient -->
+  <browser:page
+    for="bika.health.interfaces.IPatient"
+    name="ar_add"
+    class=".analysisrequests.AnalysisRequestAddRedirectView"
+    permission="senaite.core.permissions.AddAnalysisRequest"
+    layer="bika.lims.interfaces.IBikaLIMS"
+  />
 
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests makes some fields (Patient, Doctor, Client) to display default values in Add Sample form depending on the referrer url or current context.

## Current behavior before PR

Patient, Doctor and Client are not automatically set by default in Add Sample form in some cases (e.g. when creating a Sample from inside Doctor context)

## Desired behavior after PR is merged

Patient, Doctor and Client are always set by default in Add Sample form depending on the referrer url or the current context

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
