### PR TITLE
Autofill Case in Sample Add form when Batch defined in request

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Fixed**
 
+- #132 Autofill Batch field in Sample Add form when Batch defined in request
 - #131 Autofill ClientPatientID field in Sample Add form when Patient defined
 
 **Security**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #130 Allow to deactivate/activate Doctors
 
 **Changed**
 
@@ -15,6 +16,7 @@ Changelog
 
 **Fixed**
 
+- #131 Autofill ClientPatientID field in Sample Add form when Patient defined
 
 **Security**
 

--- a/bika/health/adapters/addsample.py
+++ b/bika/health/adapters/addsample.py
@@ -20,7 +20,7 @@
 
 from bika.health.interfaces import IDoctor, IPatient
 from bika.lims import api
-from bika.lims.interfaces import IGetDefaultFieldValueARAddHook, IClient
+from bika.lims.interfaces import IGetDefaultFieldValueARAddHook, IClient, IBatch
 from zope.component import adapts
 
 
@@ -66,6 +66,12 @@ class ClientDefaultFieldValue(AddFormFieldDefaultValueAdapter):
         if client:
             return client
 
+        # Try to get the client from selected Batch
+        batch = BatchDefaultFieldValue(self.request)(context)
+        client = batch and batch.getClient() or None
+        if client:
+            return client
+
         return None
 
 
@@ -93,3 +99,16 @@ class DoctorDefaultFieldValue(AddFormFieldDefaultValueAdapter):
 
         # Try with doctor explicitly defined in request
         return self.get_object_from_request_field("Doctor")
+
+
+class BatchDefaultFieldValue(AddFormFieldDefaultValueAdapter):
+    """Adapter that returns the default value for field Batch in Sample form
+    """
+    adapts(IGetDefaultFieldValueARAddHook)
+
+    def __call__(self, context):
+        if IBatch.providedBy(context):
+            return context
+
+        # Try with batch explicitly defined in request
+        return self.get_object_from_request_field("Batch")

--- a/bika/health/adapters/addsample.py
+++ b/bika/health/adapters/addsample.py
@@ -38,13 +38,11 @@ class AddFormFieldDefaultValueAdapter(object):
         return api.get_object_by_uid(uid, default=None)
 
 
-
 class ClientDefaultFieldValue(AddFormFieldDefaultValueAdapter):
     """Adapter that returns the default value for field Client in Sample form
     """
 
     adapts(IGetDefaultFieldValueARAddHook)
-
 
     def __call__(self, context):
 
@@ -71,9 +69,8 @@ class ClientDefaultFieldValue(AddFormFieldDefaultValueAdapter):
         return None
 
 
-
 class PatientDefaultFieldValue(AddFormFieldDefaultValueAdapter):
-    """Adapter that returns the default value for field Patien in Sample form
+    """Adapter that returns the default value for field Patient in Sample form
     """
     adapts(IGetDefaultFieldValueARAddHook)
 
@@ -81,16 +78,14 @@ class PatientDefaultFieldValue(AddFormFieldDefaultValueAdapter):
         if IPatient.providedBy(context):
             return context
 
-        # Try with doctor explicitly defined in request
+        # Try with patient explicitly defined in request
         return self.get_object_from_request_field("Patient")
-
 
 
 class DoctorDefaultFieldValue(AddFormFieldDefaultValueAdapter):
     """Adapter that returns the default value for field Doctor in Sample form
     """
     adapts(IGetDefaultFieldValueARAddHook)
-
 
     def __call__(self, context):
         if IDoctor.providedBy(context):

--- a/bika/health/adapters/configure.zcml
+++ b/bika/health/adapters/configure.zcml
@@ -25,6 +25,14 @@
       name = "Patient_default_value_hook"
     />
 
+    <!-- Default value for ClientPatientID field in Add Sample form -->
+    <adapter
+      factory=".addsample.PatientDefaultFieldValue"
+      for="*"
+      provides="bika.lims.interfaces.IGetDefaultFieldValueARAddHook"
+      name = "ClientPatientID_default_value_hook"
+    />
+
     <!-- Default value for Doctor field in Add Sample form -->
     <adapter
       factory=".addsample.DoctorDefaultFieldValue"

--- a/bika/health/adapters/configure.zcml
+++ b/bika/health/adapters/configure.zcml
@@ -41,4 +41,12 @@
       name = "Doctor_default_value_hook"
     />
 
+    <!-- Default value for Batch (Case) field in Add Sample form -->
+    <adapter
+      factory=".addsample.BatchDefaultFieldValue"
+      for="*"
+      provides="bika.lims.interfaces.IGetDefaultFieldValueARAddHook"
+      name="Batch_default_value_hook"
+    />
+
 </configure>

--- a/bika/health/static/js/bika.health.analysisrequest.add.js
+++ b/bika/health/static/js/bika.health.analysisrequest.add.js
@@ -11,7 +11,6 @@ function HealthAnalysisRequestAddView() {
     this.load = function () {
         datafilled = false;
         frombatch = window.location.href.search('/batches/') >= 0;
-        frompatient = document.referrer.search('/patients/') >= 0;
         fromars = window.location.href.search('/analysisrequests/') >=0;
 
         if (frombatch) {
@@ -20,12 +19,6 @@ function HealthAnalysisRequestAddView() {
             batchid = window.location.href.split("/batches/")[1].split("/")[0];
             datafilled = fillDataFromBatch(batchid);
 
-        } else if (frompatient) {
-            // The current AR add View comes from a patient AR folder view.
-            // Automatically fill the Client and Patient fields and set them
-            // as readonly.
-            pid = document.referrer.split("/patients/")[1].split("/")[0];
-            datafilled = fillDataFromPatient(pid);
         } else if(fromars){
           $('input[id^="Client-"]').bind("selected paste blur change", function () {
               colposition = get_arnum(this);
@@ -40,7 +33,7 @@ function HealthAnalysisRequestAddView() {
         // Filter ComboSearches is important here even patient is not found
         // because we are under patient's client folder.
         // Do not let other clients have ARs in this context!!!
-        if (!datafilled || frompatient) {
+        if (!datafilled) {
             // The current AR Add View doesn't come from a batch nor patient or
             // data autofilling failed. Handle event firing when Patient or
             // ClientPatientID fields change.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Requires**: https://github.com/senaite/senaite.health/pull/131

Fill the Case (`Batch`) field (from "Add Sample" form) when param `Batch` is passed in the request.

## Current behavior before PR

System omits parameter `Batch` from the request, so `Case` field is not autofilled

## Desired behavior after PR is merged

Field Case (`Batch`) in "Add Sample" form is filled automatically when `Batch` parameter with the `uid` of the `Batch` object is passed through the request.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
