### PR TITLE
System clearing patient first name on editing patient

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Changelog
 
 **Fixed**
 
+- #133 System clearing patient first name on editing patient
+
 
 **Security**
 

--- a/bika/health/static/js/bika.health.patient.js
+++ b/bika/health/static/js/bika.health.patient.js
@@ -365,9 +365,6 @@ function HealthPatientEditView() {
             }
             // Restore default visibility and required
             restore_field_defaults();
-
-            // Set default values
-            $("#patient-base-edit #Firstname").val("");
         }
     }
 

--- a/bika/health/static/js/bika.health.patient.js
+++ b/bika/health/static/js/bika.health.patient.js
@@ -373,7 +373,7 @@ function HealthPatientEditView() {
      */
     function get_field(field_id) {
         var field = $('#patient-base-edit #archetypes-fieldname-'+field_id);
-        if (!field) {
+        if (!field || field.length < 1) {
             field = $('#patient-base-edit #'+field_id);
             if (!$(field).hasClass(".field")) {
                 field = $(field).closest(".field");


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.health/issues/126

## Current behavior before PR

Empty value for `Firstname` field in Patient edit view

## Desired behavior after PR is merged

Value for `Firstname` field in Patient edit view is not empty

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
