### PR TITLE
ReferenceWidget for client searches in Add Patient form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #134 ReferenceWidget for client searches in Add Patient form
 - #130 Allow to deactivate/activate Doctors
 
 **Changed**


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Two clients might have same name, so it becomes impossible to know to which client a patient must be assigned to in Patient Add form. This Pull Request replaces the Selection list by a Reference widget that displays a suggest search with the name, the province and the district of the client.

## Current behavior before PR

User cannot distinguish between two clients that have the same name in Patient Add form.

## Desired behavior after PR is merged

User can distinguish between two clients that have the same name in Patient Add form.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
