### PR TITLE
Avoid attribute error on Patient creation

### DIFF
--- a/bika/health/validators.py
+++ b/bika/health/validators.py
@@ -73,7 +73,8 @@ class UniqueClientPatientIDValidator:
 
     def __call__(self, value, *args, **kwargs):
         # avoid the catalog query if the option is not selected
-        if not api.get_bika_setup().ClientPatientIDUnique:
+        setup = api.get_setup()
+        if not getattr(setup, "ClientPatientIDUnique", False):
             return True
         query = dict(getClientPatientID=value)
         patients = api.search(query, CATALOG_PATIENTS)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an `AttributeError` when `senaite.health` has been initially installed and a new patient is created.

The problem that arises here is that the extended field `ClientPatientIDUnique` is first accessible when the `setup` object has been once saved.

## Current behavior before PR

`AttributeError` on Patient Creation

## Desired behavior after PR is merged

No `AttributeError` on patient creation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
