### PR TITLE
Remove identifiers

### DIFF
--- a/bika/health/browser/identifiertype/configure.zcml
+++ b/bika/health/browser/identifiertype/configure.zcml
@@ -4,12 +4,12 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="senaite.health">
 
-    <!--browser:page
+    <browser:page
       for="*"
       name="getidentifiertypes"
       class=".getidentifiertypes.ajaxGetIdentifierTypes"
       permission="zope.Public"
       layer="bika.health.interfaces.IBikaHealth"
-    /-->
+    />
 
 </configure>

--- a/bika/health/browser/patients/folder_view.py
+++ b/bika/health/browser/patients/folder_view.py
@@ -91,6 +91,12 @@ class PatientsView(BikaListingView):
                 'replace_url': 'getPrimaryReferrerURL',
                 'toggle': True,
                 'sortable': False}),
+
+            ('getPatientIdentifiersStr', {
+                'title': _('Additional IDs'),
+                'attr': 'getPatientIdentifiersStr',
+                'toggle': False,
+                'sortable': False}),
         ))
 
         self.review_states = [

--- a/bika/health/catalog/indexers/patient.py
+++ b/bika/health/catalog/indexers/patient.py
@@ -33,7 +33,8 @@ def listing_searchable_text(instance):
         "getId",
         "getPrimaryReferrerID",
         "getPrimaryReferrerTitle",
-        "getClientPatientID"
+        "getClientPatientID",
+        "getPatientIdentifiersStr"
     ]
 
     def get_value(instance, func_name):

--- a/bika/health/content/patient.py
+++ b/bika/health/content/patient.py
@@ -903,20 +903,19 @@ class Patient(Person):
             ret.append((ic.UID, ic.Title))
         return DisplayList(ret)
 
-    def getPatientIdentifiersStr(self):
+    def getPatientIdentifiersList(self):
+        """Returns a list with the additional identifiers for this patient
+        """
         ids = self.getPatientIdentifiers()
-        idsstr = ''
-        for idx in ids:
-            idsstr += idsstr == '' and idx.get('Identifier', '') or (', ' + idx.get('Identifier', ''))
-        return idsstr
-        # return self.getSendersPatientID()+" "+self.getSendersCaseID()+" "+self.getSendersSpecimenID()
+        ids = map(lambda patient_id: patient_id.get("Identifier"), ids)
+        return filter(None, ids)
 
-    def getPatientIdentifiersStrHtml(self):
-        ids = self.getPatientIdentifiers()
-        idsstr = '<table cellpadding="0" cellspacing="0" border="0" class="patientsidentifiers" style="text-align:left;width: 100%;"><tr><td>'
-        for idx in ids:
-            idsstr += "<tr><td>" + idx['IdentifierType'] + ':</td><td>' + idx['Identifier'] + "</td></tr>"
-        return "</table>" + idsstr
+    def getPatientIdentifiersStr(self):
+        """Returns a string representation of the additional identifiers for
+        this patient
+        """
+        ids = self.getPatientIdentifiersList()
+        return " ".join(ids)
 
     def getAgeSplitted(self):
 

--- a/bika/health/controlpanel/bika_identifiertypes.py
+++ b/bika/health/controlpanel/bika_identifiertypes.py
@@ -30,6 +30,7 @@ from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.folder.folder import ATFolder, ATFolderSchema
 from zope.interface.declarations import implements
 
+
 class IdentifierTypesView(BikaListingView):
     implements(IFolderContentsView, IViewView)
 
@@ -43,7 +44,6 @@ class IdentifierTypesView(BikaListingView):
                                  'icon': '++resource++bika.lims.images/add.png'}}
         self.title = self.context.translate(_("Identifier Types"))
         self.icon = self.portal_url + "/++resource++bika.health.images/identifiertype_big.png"
-        self.description = _("List of types of identifiers for multiple identifier records")
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True

--- a/bika/health/upgrade/v01_02_002.py
+++ b/bika/health/upgrade/v01_02_002.py
@@ -17,12 +17,15 @@
 #
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
+from Products.CMFPlone.utils import _createObjectByType
 
-from bika.health import logger
+from bika.health import logger, CATALOG_PATIENTS
 from bika.health.config import PROJECTNAME
 from bika.lims import api
+from bika.lims.idserver import renameAfterCreation
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
+from bika.lims.utils import tmpID
 
 version = '1.2.2'
 profile = 'profile-{0}:default'.format(PROJECTNAME)
@@ -44,10 +47,18 @@ def upgrade(tool):
                                                    version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    setup.runImportStepFromProfile(profile, "typeinfo")
+    setup.runImportStepFromProfile(profile, "controlpanel")
     setup.runImportStepFromProfile(profile, 'rolemap')
     setup.runImportStepFromProfile(profile, 'workflow')
 
-    apply_doctor_permissions_for_clients(portal, ut)
+    #apply_doctor_permissions_for_clients(portal, ut)
+
+    # IdentifierType is no longer provided by core, but this content type is
+    # still used in health to provide additional identification criteria for
+    # Patients (e.g. drive license, passport, etc.)
+    # https://github.com/senaite/senaite.core/pull/1430
+    restore_identifier_types(portal)
 
     logger.info("{0} upgraded to version {1}".format(PROJECTNAME, version))
     return True
@@ -75,3 +86,58 @@ def apply_doctor_permissions_for_clients(portal, ut):
     logger.info(
         "Changed permissions for doctor objects: " +
         "{0}/{1}".format(counter, total))
+
+
+def restore_identifier_types(portal):
+    """Restores the identifier types by using the values stored in patients
+    """
+    logger.info("Restoring additional identifiers for Patients ...")
+
+    # Re-create the Identifier types folder in setup
+    setup = api.get_setup()
+    if "bika_identifiertypes" not in setup:
+        obj = _createObjectByType("IdentifierTypes", setup, "bika_identifiertypes")
+        obj.edit(title="Identifier Types")
+        obj.unmarkCreationFlag()
+        obj.reindexObject()
+
+    # Infer the Identifier Types to be restored from Patients
+    query = dict(portal_type="Patient")
+    brains = api.search(query, CATALOG_PATIENTS)
+    for brain in brains:
+        ids = brain.getPatientIdentifiersStr
+        if ids and ids not in [", "]:
+            # Restore the IdentifierType by using the value stored in Patient
+            obj = api.get_object(brain)
+            restore_identifier_type(obj)
+
+
+def restore_identifier_type(patient):
+    """Restores the identifier types for the Patient passed in
+    """
+    patient_ids = patient.__dict__.get("PatientIdentifiers", [])
+    for patient_id in patient_ids:
+        identifier_id = patient_id.get("IdentifierType")
+        id_value = patient_id.get("Identifier") or patient_id.get("value")
+        if identifier_id and id_value:
+            resolve_identifier_type(identifier_id)
+
+
+def resolve_identifier_type(identifier_id):
+    """Search for an identifier type with an ID that matches with the id
+    passed in. If no identifier type is found, creates a new one
+    """
+    setup = api.get_setup()
+    folder = setup.bika_identifiertypes
+    id_types = folder.objectValues()
+    for id_type in id_types:
+        if api.get_title(id_type) == identifier_id:
+            return id_type
+
+    # Create a new identifier type
+    logger.info("Creating new Identifier Type: {}".format(identifier_id))
+    obj = _createObjectByType('IdentifierType', folder, tmpID())
+    obj.edit(title=identifier_id, description=identifier_id)
+    obj.unmarkCreationFlag()
+    renameAfterCreation(obj)
+    return obj


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests makes senaite.health compatible with the removal of IdentifierType content type in https://github.com/senaite/senaite.core/pull/1430

The Pull Request restore the IdentifierType content type and walks through the Patients registered in the system to restore the Identifier types stored previously.

## Current behavior before PR

Identifier Types (used in Patients) are no longer available

## Desired behavior after PR is merged

Identifier Types are restored and available through Patient edit view.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
