### PR TITLE
Move skin layer after the custom layer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog
 
 **Fixed**
 
+- #146 Move skin layer after the custom layer
 - #141 Unable to Deactivate Doctors
 - #137 Client reference widget does not work in Add Patient overlay
 - #133 System clearing patient first name on editing patient

--- a/bika/health/profiles/default/skins.xml
+++ b/bika/health/profiles/default/skins.xml
@@ -12,7 +12,7 @@
           directory="bika.health:skins/bika_health"/>
 
   <skin-path name="*">
-    <layer name="bika_health" insert-before="custom"/>
+    <layer name="bika_health" insert-after="custom"/>
   </skin-path>
 
 </object>

--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -85,12 +85,6 @@ def post_install(portal_setup):
     logger.info("SENAITE Health post-install handler [BEGIN]")
     context = portal_setup._getImportContext(DEFAULT_PROFILE_ID)
     portal = context.getSite()
-
-    # When installing senaite health together with core, health's skins are not
-    # set before core's, even if after-before is set in profiles/skins.xml
-    # Ensure health's skin layer(s) always gets priority over core's
-    portal_setup.runImportStepFromProfile(DEFAULT_PROFILE_ID, "skins")
-
     # Setup catalogs
     # TODO use upgrade.utils.setup_catalogs instead!
     setup_health_catalogs(portal)
@@ -118,6 +112,11 @@ def post_install(portal_setup):
 
     # Setup default ethnicities
     setup_ethnicities(portal)
+
+    # When installing senaite health together with core, health's skins are not
+    # set before core's, even if after-before is set in profiles/skins.xml
+    # Ensure health's skin layer(s) always gets priority over core's
+    portal_setup.runImportStepFromProfile(DEFAULT_PROFILE_ID, "skins")
 
     logger.info("SENAITE Health post-install handler [DONE]")
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the order of the skin layers

## Current behavior before PR

Skin layer for senaite.health is registered **before** the `custom` layer:

<img width="561" alt="Controls skin behaviour (search order etc) 2019-10-10 09-40-14" src="https://user-images.githubusercontent.com/713193/66548683-0671c900-eb42-11e9-98a0-bc91a17771ba.png">

=> No Logo overrides possible from an Add-on

## Desired behavior after PR is merged

Skin layer for senaite.health is registered **after** the `custom` layer:

<img width="562" alt="Controls skin behaviour (search order etc) 2019-10-10 12-37-46" src="https://user-images.githubusercontent.com/713193/66561933-c66b1000-eb5a-11e9-8769-ec6bc9da09b3.png">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
