### PR TITLE
Delete overridden indexes for batches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Changelog
 
 **Removed**
 
-- #148 Removd getClientUID and getClientTitle indexers for Batch
+- #148 Removed getClientID, getClientUID, getClientTitle indexers for Batch
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Changelog
 
 
 **Removed**
-
+- getClientUID and getClientTitle indexers in Batch
 
 **Fixed**
 

--- a/bika/health/browser/batch/getbatchinfo.py
+++ b/bika/health/browser/batch/getbatchinfo.py
@@ -33,7 +33,7 @@ class ajaxGetBatchInfo(BrowserView):
     def __call__(self):
         plone.protect.CheckAuthenticator(self.request)
         batch = self.context
-        client = batch.Schema()['Client'].get(batch)
+        client = batch.getClient()
         doctor = batch.Schema()['Doctor'].get(batch)
         patient = batch.Schema()['Patient'].get(batch)
 

--- a/bika/health/content/batch.py
+++ b/bika/health/content/batch.py
@@ -125,12 +125,6 @@ def getDoctorTitle(instance):
     return value
 
 @indexer(IBatch)
-def getClientID(instance):
-    item = instance.Schema()['Client'].get(instance)
-    value = item and item.Schema()['ClientID'].get(item) or ''
-    return value
-
-@indexer(IBatch)
 def getClientPatientID(instance):
     return ClientPatientIDGetter(instance)
 

--- a/bika/health/content/batch.py
+++ b/bika/health/content/batch.py
@@ -131,18 +131,6 @@ def getClientID(instance):
     return value
 
 @indexer(IBatch)
-def getClientUID(instance):
-    item = instance.Schema()['Client'].get(instance)
-    value = item and item.UID() or ''
-    return value
-
-@indexer(IBatch)
-def getClientTitle(instance):
-    item = instance.Schema()['Client'].get(instance)
-    value = item and item.Title() or ''
-    return value
-
-@indexer(IBatch)
 def getClientPatientID(instance):
     return ClientPatientIDGetter(instance)
 

--- a/bika/health/content/client.py
+++ b/bika/health/content/client.py
@@ -20,18 +20,12 @@
 
 """ http://pypi.python.org/pypi/archetypes.schemaextender
 """
-from Products.Archetypes.public import *
+from archetypes.schemaextender.interfaces import IOrderableSchemaExtender
+from bika.health import bikaMessageFactory as _
 from bika.lims.fields import *
 from bika.lims.interfaces import IClient
-from bika.health.widgets import *
-from plone.indexer.decorator import indexer
-from bika.health import bikaMessageFactory as _
-from zope.component import adapts, getAdapters
-from archetypes.schemaextender.interfaces import IOrderableSchemaExtender
-
-@indexer(IClient)
-def getClientID(instance):
-    return instance.Schema()['ClientID'].get(instance)
+from zope.component import adapts
+from zope.interface import implements
 
 
 class ClientSchemaExtender(object):

--- a/bika/health/content/configure.zcml
+++ b/bika/health/content/configure.zcml
@@ -20,7 +20,6 @@
     <adapter factory=".batch.getDoctorID" name="getDoctorID" />
     <adapter factory=".batch.getDoctorUID" name="getDoctorUID" />
     <adapter factory=".batch.getDoctorTitle" name="getDoctorTitle" />
-    <adapter factory=".batch.getClientID" name="getClientID" />
     <adapter factory=".client.getClientID" name="getClientID" />
 
     <adapter factory=".analysis.AnalysisSchemaExtender" />

--- a/bika/health/content/configure.zcml
+++ b/bika/health/content/configure.zcml
@@ -20,7 +20,6 @@
     <adapter factory=".batch.getDoctorID" name="getDoctorID" />
     <adapter factory=".batch.getDoctorUID" name="getDoctorUID" />
     <adapter factory=".batch.getDoctorTitle" name="getDoctorTitle" />
-    <adapter factory=".client.getClientID" name="getClientID" />
 
     <adapter factory=".analysis.AnalysisSchemaExtender" />
     <adapter factory=".analysisspec.AnalysisSpecSchemaModifier" />

--- a/bika/health/content/configure.zcml
+++ b/bika/health/content/configure.zcml
@@ -21,8 +21,6 @@
     <adapter factory=".batch.getDoctorUID" name="getDoctorUID" />
     <adapter factory=".batch.getDoctorTitle" name="getDoctorTitle" />
     <adapter factory=".batch.getClientID" name="getClientID" />
-    <adapter factory=".batch.getClientUID" name="getClientUID" />
-    <adapter factory=".batch.getClientTitle" name="getClientTitle" />
     <adapter factory=".client.getClientID" name="getClientID" />
 
     <adapter factory=".analysis.AnalysisSchemaExtender" />


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Batches were not being reindexed properly because the indexes defined in health were getting the Client value form the schema instead of using the proper method self.getClient()

## Current behavior before PR

Two batch indexes were not reindexed properly.

## Desired behavior after PR is merged

getClientUID and getClientTitle indexes are being indexed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
