### PR TITLE
Move Patients inside Clients folders when client assigned

### DIFF
--- a/bika/health/catalog/indexers/patient.py
+++ b/bika/health/catalog/indexers/patient.py
@@ -52,7 +52,7 @@ def listing_searchable_text(instance):
 
     return " ".join(out_values)
 
-
+# TODO Remove Patient's client_uid indexer?
 @indexer(IPatient)
 def client_uid(instance):
     """Returns the uid of the Client assigned to the Patient, if any. Otherwise
@@ -64,6 +64,7 @@ def client_uid(instance):
     return "-1"
 
 
+# TODO Remove Patient's client_assigned indexer?
 @indexer(IPatient)
 def client_assigned(instance):
     """Returns whether the Patient belongs to a Client or not

--- a/bika/health/content/patient.py
+++ b/bika/health/content/patient.py
@@ -26,7 +26,10 @@ from Products.Archetypes import atapi
 from Products.Archetypes.public import *
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
+from zope.interface import implements
+
 from bika.health import bikaMessageFactory as _
+from bika.health import logger
 from bika.health.config import *
 from bika.health.interfaces import IPatient
 from bika.health.utils import translate_i18n as t
@@ -46,7 +49,7 @@ from bika.lims.browser.widgets.remarkswidget import RemarksWidget
 from bika.lims.catalog.analysisrequest_catalog import \
     CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.content.person import Person
-from zope.interface import implements
+from bika.lims.interfaces import IClient
 
 schema = Person.schema.copy() + Schema((
     StringField(
@@ -83,25 +86,25 @@ schema = Person.schema.copy() + Schema((
     ),
     ComputedField(
         'PrimaryReferrerID',
-        expression="context.Schema()['PrimaryReferrer'].get(context) and context.Schema()['PrimaryReferrer'].get(context).getId() or None",
+        expression="context.getClientID()",
         widget=ComputedWidget(
         ),
     ),
     ComputedField(
         'PrimaryReferrerTitle',
-        expression="context.Schema()['PrimaryReferrer'].get(context) and context.Schema()['PrimaryReferrer'].get(context).Title() or None",
+        expression="context.getClientTitle()",
         widget=ComputedWidget(
         ),
     ),
     ComputedField(
         'PrimaryReferrerUID',
-        expression="context.Schema()['PrimaryReferrer'].get(context) and context.Schema()['PrimaryReferrer'].get(context).UID() or None",
+        expression="context.getClientUID()",
         widget=ComputedWidget(
         ),
     ),
     ComputedField(
         'PrimaryReferrerURL',
-        expression="context.getPrimaryReferrer().absolute_url_path() if context.getPrimaryReferrer() else ''",
+        expression="context.getClientURL()",
         widget=ComputedWidget(
             visible=False
         ),
@@ -1071,11 +1074,61 @@ class Patient(Person):
         """
         return self.objectValues('Multifile')
 
-    # TODO Replace "PrimaryReferrer" field from the Schema by "Client"
-    def getClient(self):
-        """Returns the client associated to this Patient, if any
+    def getPrimaryReferrer(self):
+        """Returns the client the current Patient is assigned to. Delegates the
+        action to function getClient.
+        NOTE: This is kept for backwards compatibility
         """
-        return self.getPrimaryReferrer() or None
+        logger.warn("Patient.getPrimaryReferrer: better use 'getClient'")
+        return self.getClient()
+
+    def getClient(self):
+        """Returns the client the current Patient is assigned to, if any
+        """
+        # The schema's field PrimaryReferrer is only used to allow the user to
+        # assign the patient to a client in edit form. The entered value is used
+        # in ObjectModifiedEventHandler to move the patient to the Client's
+        # folder, so the value stored in the Schema's is not used anymore
+        # See https://github.com/senaite/senaite.core/pull/152
+        client = self.aq_parent
+        if IClient.providedBy(client):
+            return client
+        return None
+
+    def setClient(self, value):
+        """Sets the client the current Patient has to be assigned to
+        """
+        self.setPrimaryReferrer(value)
+
+    def getClientID(self):
+        """Returns the ID of the client this Patient belongs to or None
+        """
+        client = self.getClient()
+        return client and api.get_id(client) or None
+
+    def getClientUID(self):
+        """Returns the UID of the client this Patient belongs to or None
+        """
+        client = self.getClient()
+        return client and api.get_uid(client) or None
+
+    def getClientURL(self):
+        """Returns the URL of the client this Patient belongs to or None
+        """
+        client = self.getClient()
+        return client and api.get_url(client) or None
+
+    def getClientTitle(self):
+        """Returns the title of the client this Patient belongs to or None
+        """
+        client = self.getClient()
+        return client and api.get_title(client) or None
+
+    def getBatches(self):
+        """Returns the Batches (Clinic Cases) this Patient is assigned to
+        """
+        batches = self.getBackReferences("BatchPatient")
+        return batches or []
 
 
     def SearchableText(self):

--- a/bika/health/profiles/default/types/Patient.xml
+++ b/bika/health/profiles/default/types/Patient.xml
@@ -16,6 +16,7 @@
  <property name="filter_content_types">True</property>
  <property name="allowed_content_types">
      <element value="Multifile"/>
+     <element value="Batch"/>
  </property>
  <property name="allow_discussion">False</property>
  <property name="default_view_fallback">False</property>

--- a/bika/health/profiles/default/workflows.xml
+++ b/bika/health/profiles/default/workflows.xml
@@ -12,6 +12,9 @@
   <!-- Workflow: bika_doctor_workflow -->
   <object name="senaite_health_doctor_workflow" meta_type="Workflow"/>
 
+  <!-- Workflow for base patients folder -->
+  <object name="senaite_health_patients_workflow" meta_type="Workflow"/>
+
   <!-- Workflow: bika_patient_workflow -->
   <object name="senaite_health_patient_workflow" meta_type="Workflow"/>
 
@@ -68,9 +71,6 @@
     <bound-workflow workflow_id="senaite_one_state_workflow"/>
   </type>
   <!-- Other folders and types -->
-  <type type_id="Patients">
-    <bound-workflow workflow_id="senaite_one_state_workflow"/>
-  </type>
   <type type_id="Doctors">
     <bound-workflow workflow_id="senaite_one_state_workflow"/>
   </type>
@@ -128,6 +128,9 @@
   <!-- *** BINDINGS TO SENAITE.HEALTH WORKFLOWS *** -->
   <type type_id="Doctor">
    <bound-workflow workflow_id="senaite_health_doctor_workflow"/>
+  </type>
+  <type type_id="Patients">
+    <bound-workflow workflow_id="senaite_health_patients_workflow"/>
   </type>
   <type type_id="Patient">
    <bound-workflow workflow_id="senaite_health_patient_workflow"/>

--- a/bika/health/profiles/default/workflows/senaite_health_patient_workflow/definition.xml
+++ b/bika/health/profiles/default/workflows/senaite_health_patient_workflow/definition.xml
@@ -32,7 +32,18 @@
      <permission-role>Manager</permission-role>
      <permission-role>Owner</permission-role>
     </permission-map>
-    <permission-map name="Delete objects" acquired="False"/>
+    <permission-map name="Delete objects" acquired="False">
+      <!-- Same roles as those that have Modify Portal Content permission
+       This is necessary, cause Batches that are created inside Patient are
+       moved by ObjectModifyEvent to parent folder. This trick is used to
+       auto-fill the Patient in the Batch on creation
+       -->
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+
     <permission-map name="List folder contents" acquired="False">
      <permission-role>Doctor</permission-role>
      <permission-role>LabClerk</permission-role>

--- a/bika/health/profiles/default/workflows/senaite_health_patients_workflow/definition.xml
+++ b/bika/health/profiles/default/workflows/senaite_health_patients_workflow/definition.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<dc-workflow xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+             i18n:domain="senaite.health"
+             workflow_id="senaite_health_patients_workflow"
+             title="Senaite Health patients folder Workflow"
+             state_variable="review_state"
+             initial_state="active"
+             manager_bypass="False">
+
+  <!--
+  Workflow based on one-state (active) workflow, but includes the permission
+  Delete objects to allow lab personnel to move patient objects to client
+  folders when they assign a client to a Patient (see subscribers/patient).
+  Allowing to move patients to client folders grants access to client contacts.
+  -->
+
+  <permission>Access contents information</permission>
+  <permission>Delete objects</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify portal content</permission>
+  <permission>View</permission>
+
+  <!-- State: active -->
+  <state state_id="active" title="Active" i18n:attributes="title">
+    <exit-transition transition_id="" />
+    <permission-map name="Access contents information" acquired="True" />
+    <permission-map name="Delete objects" acquired="False">
+      <!-- Same roles as those that have Modify Portal Content permission -->
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="List folder contents" acquired="True" />
+    <permission-map name="Modify portal content" acquired="True" />
+    <permission-map name="View" acquired="True" />
+  </state>
+
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+      <expression>transition/getId|nothing</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+    <description>The ID of the user who performed the last transition</description>
+    <default>
+      <expression>user/getId</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+      <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+      <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+      <expression>state_change/getDateTime</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+</dc-workflow>

--- a/bika/health/subscribers/configure.zcml
+++ b/bika/health/subscribers/configure.zcml
@@ -1,22 +1,12 @@
 <configure xmlns="http://namespaces.zope.org/zope"
            i18n_domain="senaite.core">
 
-  <!-- Patient creation. If a client has been assigned to the patient, client
-   contacts become the Owners of the Patient, so besides lab personnel, only
-   contacts of same client will be able to view and edit the patient -->
-  <subscriber
-    for="bika.health.interfaces.IPatient
-         Products.Archetypes.interfaces.IObjectInitializedEvent"
-    handler=".patient.ObjectInitializedEventHandler"
-  />
-
-  <!-- Patient modification. Purges role "Owner" for this patient from client
-   contacts that do not belong to the same client the patient is assigned to -->
+  <!-- Patient modification. If the patient has a client assigned, this event
+   moves the Patient into the Client's folder -->
   <subscriber
     for="bika.health.interfaces.IPatient
          zope.lifecycleevent.interfaces.IObjectModifiedEvent"
-    handler=".patient.ObjectModifiedEventHandler"
-  />
+    handler=".patient.ObjectModifiedEventHandler" />
 
   <!-- Batch creation. If a client has been assigned to the batch, client
    contacts become the Owners of the Batch, so besides lab personnel, only


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows Client objects to contain Patients. When a Client is assigned to a Patient, the Patient is automatically moved inside it's client folder. Thus, client contacts can have access to their own Patients without having to assign "Owner" roles individually.

There are two types of Patients:

- (Lab) Patients: accessible for all client contacts
- (Client) Patients: accessible only for contacts that belong to same client as the patient

## Current behavior before PR

The assignment of Client to a Patient requires a lot of workarounds to filter their accessibility by different users. Assignment/Unassignment of local role "Owner" is required for client contacts, making the Patient creation/edition process slow.

## Desired behavior after PR is merged

The assignment of Client to a Patient does not require additional actions other than moving the Patient inside Client's folder to guarantee access/view permissions.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
