### PR TITLE
VaccinationCenters listing: index getName --> sortable_title

### DIFF
--- a/bika/health/controlpanel/bika_vaccinationcenters.py
+++ b/bika/health/controlpanel/bika_vaccinationcenters.py
@@ -15,110 +15,135 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# Copyright 2018-2019 by it's authors.
+# Copyright 2018-2019 by it"s authors.
 # Some rights reserved, see README and LICENSE.
 
-from AccessControl.SecurityInfo import ClassSecurityInfo
+import collections
+
 from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
-from Products.Archetypes.ArchetypeTool import registerType
-from Products.Archetypes.public import *
-from Products.CMFCore import permissions
-from Products.CMFCore.utils import getToolByName
-from ZODB.POSException import ConflictError
-from bika.lims import bikaMessageFactory as _b
-from bika.health import bikaMessageFactory as _
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.health.config import PROJECTNAME
-from bika.lims.content.bikaschema import BikaFolderSchema
-from bika.health.interfaces import IVaccinationCenters
-from bika.lims.interfaces import IHaveNoBreadCrumbs
-from operator import itemgetter
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
 from plone.app.layout.globals.interfaces import IViewView
 from zope.interface import implements
 
+from bika.health import bikaMessageFactory as _
+from bika.health.config import PROJECTNAME
+from bika.health.interfaces import IVaccinationCenters
+from bika.health.permissions import AddVaccinationCenter
+from bika.lims import api
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.catalog.bikasetup_catalog import SETUP_CATALOG
+from bika.lims.utils import get_link
+
+
+# TODO: Separate content and view into own modules!
+
+
 class VaccinationCentersView(BikaListingView):
     implements(IFolderContentsView, IViewView)
+
     def __init__(self, context, request):
         super(VaccinationCentersView, self).__init__(context, request)
-        self.catalog = 'bika_setup_catalog'
-        self.contentFilter = {'portal_type': 'VaccinationCenter',
-                              'sort_on': 'getName'}
-        self.context_actions = {_('Add'):
-                                {'url': 'createObject?type_name=VaccinationCenter',
-                                 'icon': '++resource++bika.lims.images/add.png'}}
+
+        self.catalog = SETUP_CATALOG
+        self.contentFilter = dict(
+            portal_type="VaccinationCenter",
+            sort_on="sortable_title"
+        )
+
+        self.context_actions = {
+            _("Add"): {
+                "url": "createObject?type_name=VaccinationCenter",
+                "permission": AddVaccinationCenter,
+                "icon": "++resource++bika.lims.images/add.png"}
+        }
+
         self.title = self.context.translate(_("Vaccination Centers"))
-        self.icon = self.portal_url + "/++resource++bika.health.images/vaccinationcenter_big.png"
-        self.description = ""
-        self.show_sort_column = False
+        self.icon = "{}/{}".format(
+            self.portal_url,
+            "/++resource++bika.health.images/vaccinationcenter_big.png"
+        )
+
         self.show_select_row = False
         self.show_select_column = True
         self.pagesize = 50
 
-        self.columns = {
-            'Name': {'title': _('Name'),
-                     'index': 'getName'},
-            'Email': {'title': _('Email'),
-                      'toggle': True},
-            'Phone': {'title': _('Phone'),
-                      'toggle': True},
-            'Fax': {'title': _('Fax'),
-                    'toggle': True},
-        }
+        self.columns = collections.OrderedDict((
+            ("Name", {
+                "title": _("Name"),
+                "index": "sortable_title"
+            }),
+            ("Email", {
+                "title": _("Email"),
+                "toggle": True
+            }),
+            ("Phone", {
+                "title": _("Phone"),
+                "toggle": True
+            }),
+            ("Fax", {
+                "title": _("Fax"),
+                "toggle": True
+            }),
+        ))
+
         self.review_states = [
-            {'id':'default',
-             'title': _('Active'),
-             'contentFilter': {'is_active': True},
-             'transitions': [{'id':'deactivate'}, ],
-             'columns': ['Name',
-                         'Email',
-                         'Phone',
-                         'Fax']},
-            {'id':'inactive',
-             'title': _('Dormant'),
-             'contentFilter': {'is_active': False},
-             'transitions': [{'id':'activate'}, ],
-             'columns': ['Name',
-                         'Email',
-                         'Phone',
-                         'Fax']},
-            {'id':'all',
-             'title': _('All'),
-             'contentFilter':{},
-             'columns': ['Name',
-                         'Email',
-                         'Phone',
-                         'Fax']},
+            {
+                "id":"default",
+                "title": _("Active"),
+                "contentFilter": {"is_active": True},
+                "transitions": [{"id": "deactivate"}, ],
+                "columns": self.columns.keys(),
+            }, {
+                "id":"inactive",
+                "title": _("Dormant"),
+                "contentFilter": {"is_active": False},
+                "transitions": [{"id": "activate"}, ],
+                "columns": self.columns.keys(),
+            }, {
+                "id":"all",
+                "title": _("All"),
+                "contentFilter":{},
+                "columns": self.columns.keys(),
+            },
         ]
 
     def before_render(self):
         """Before template render hook
         """
         super(VaccinationCentersView, self).before_render()
-        # Don't allow any context actions on Vaccination Centers folder
+        # Don"t allow any context actions
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Name'] = obj.getName()
-            items[x]['Email'] = obj.getEmailAddress()
-            items[x]['Phone'] = obj.getPhone()
-            items[x]['Fax'] = obj.getFax()
-            items[x]['replace']['Name'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Name'])
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
+        The use of this service prevents the extra-loops in child objects.
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+        name = obj.getName()
+        url = api.get_url(obj)
 
-        return items
+        item["Email"] = obj.getEmailAddress()
+        item["Phone"] = obj.getPhone()
+        item["Fax"] = obj.getFax()
+        item["replace"]["Name"] = get_link(url, value=name)
+
+        return item
+
 
 schema = ATFolderSchema.copy()
+
+
 class VaccinationCenters(ATFolder):
     implements(IVaccinationCenters)
     displayContentsTab = False
     schema = schema
+
 
 schemata.finalizeATCTSchema(schema, folderish = True, moveDiscussion = False)
 atapi.registerType(VaccinationCenters, PROJECTNAME)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Makes compatible `senaite.health` with [#1486 Indexes and metadata cleanup for `setup_catalog`](https://github.com/senaite/senaite.core/pull/1486)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
