### PR TITLE
Changed Base Catalog Tool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Changelog
 
 **Changed**
 
+- #157 Changed Base Catalog Tool
+
 
 **Removed**
 

--- a/bika/health/catalog/patient_catalog.py
+++ b/bika/health/catalog/patient_catalog.py
@@ -20,7 +20,7 @@
 
 from App.class_init import InitializeClass
 from bika.health.interfaces import IBikaHealthCatalogPatientListing
-from bika.lims.catalog.bika_catalog_tool import BikaCatalogTool
+from bika.lims.catalog.base import BaseCatalog
 from bika.lims.catalog.catalog_basic_template import BASE_CATALOG_COLUMNS
 from bika.lims.catalog.catalog_basic_template import BASE_CATALOG_INDEXES
 from zope.interface import implements
@@ -74,14 +74,14 @@ patient_catalog_definition = {
 }
 
 
-class BikaHealthCatalogPatientListing(BikaCatalogTool):
+class BikaHealthCatalogPatientListing(BaseCatalog):
     """
     Catalog to list patients in BikaListing
     """
     implements(IBikaHealthCatalogPatientListing)
 
     def __init__(self):
-        BikaCatalogTool.__init__(
+        BaseCatalog.__init__(
             self, CATALOG_PATIENTS,
             "Senaite Health Catalog Patients",
             "BikaHealthCatalogPatientListing")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

See: https://github.com/senaite/senaite.core/pull/1487

## Current behavior before PR

Base Class: `bika.lims.catalog.bika_catalog_tool.BikaCatalogTool`

## Desired behavior after PR is merged

Base Class: `bika.lims.catalog.base.BaseCatalog`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
