### PR TITLE
Fix the filter query in the Add Sample Form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Changelog
 
 **Fixed**
 
+- #158 Fix the filter query in the Add Sample Form
+
 
 **Security**
 

--- a/bika/health/adapters/addsample.py
+++ b/bika/health/adapters/addsample.py
@@ -138,10 +138,10 @@ class AddSampleClientInfo(AddSampleObjectInfoAdapter):
         filter_queries = {
             # Allow to choose Patients from same Client only
             "Patient": {
-                "getPrimaryReferrerUID": [uid, ""],
+                "getPrimaryReferrerUID": [uid, None],
             },
             "ClientPatientID": {
-                "getPrimaryReferrerUID": [uid, ""],
+                "getPrimaryReferrerUID": [uid, None],
             }
         }
         object_info["filter_queries"] = filter_queries


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the filter query for the Patient field in the Sample Add Form.

## Current behavior before PR

No patients were found, although unassigned patients exist.

## Desired behavior after PR is merged

Patients not assigned to a client are found.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
