### PR TITLE
Ensure `Client` contents allow to hold `Patient` types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Changelog
 
 **Fixed**
 
+- #159 Ensure `Client` contents allow to hold `Patient` types
+
 
 **Security**
 

--- a/bika/health/subscribers/configure.zcml
+++ b/bika/health/subscribers/configure.zcml
@@ -1,6 +1,12 @@
 <configure xmlns="http://namespaces.zope.org/zope"
            i18n_domain="senaite.core">
 
+  <!-- Patient creation. Allow to create Patient content types inside Client -->
+  <subscriber
+    for="bika.health.interfaces.IPatient
+         zope.lifecycleevent.interfaces.IObjectCreatedEvent"
+    handler=".patient.ObjectCreatedEventHandler" />
+
   <!-- Patient modification. If the patient has a client assigned, this event
    moves the Patient into the Client's folder -->
   <subscriber

--- a/bika/health/subscribers/patient.py
+++ b/bika/health/subscribers/patient.py
@@ -35,9 +35,17 @@ def ObjectModifiedEventHandler(patient, event):
 
     # Check if the Patient is being created inside the Client
     if client and client.UID() != patient.aq_parent.UID():
+        # Ensure `Client` contents allow to hold `Patient` types
+        portal_types = api.get_tool("portal_types")
+        client_fti = portal_types.getTypeInfo("Client")
+        allowed_types = client_fti.allowed_content_types
+        if "Patient" not in allowed_types:
+            client_fti.allowed_content_types = allowed_types + ("Patient", )
+
         # Move the Patient inside the client
         cp = patient.aq_parent.manage_cutObjects(patient.id)
         client.manage_pasteObjects(cp)
+
 
 # TODO: This is no longer needed!
 def assign_owners_for(patient):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR ensures that Patients can be moved below their assigned Client after creation.

## Current behavior before PR

If an upgrade step from `senaite.core` ran the `typeinfo` upgrade step, the allowed types was set back to the defaults, which does not allow `Patient` types.

This resulted in this error:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 91, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 29, in _call
  Module Products.CMFFormController.ControllerBase, line 232, in getNext
  Module Products.CMFFormController.Actions.TraverseTo, line 38, in __call__
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPythonScript, line 105, in __call__
  Module Products.CMFFormController.Script, line 145, in __call__
  Module Products.CMFCore.FSPythonScript, line 127, in __call__
  Module Shared.DC.Scripts.Bindings, line 322, in __call__
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 344, in _exec
  Module script, line 1, in content_edit
   - <FSControllerPythonScript at /senaite/patients/patient-12/content_edit>
   - Line 1
  Module Products.CMFCore.FSPythonScript, line 127, in __call__
  Module Shared.DC.Scripts.Bindings, line 322, in __call__
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 344, in _exec
  Module script, line 12, in content_edit_impl
   - <FSPythonScript at /senaite/patients/patient-12/content_edit_impl>
   - Line 12
  Module Products.Archetypes.BaseObject, line 645, in processForm
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module bika.health.subscribers.patient, line 43, in ObjectModifiedEventHandler
  Module OFS.CopySupport, line 332, in manage_pasteObjects
  Module OFS.CopySupport, line 208, in _pasteObjects
  Module Products.CMFCore.PortalFolder, line 421, in _verifyObjectPaste
ValueError: Disallowed subobject type: Patient
```

## Desired behavior after PR is merged

The FTI of `Client` is checked in the event handler to ensure that `Patient` can be added


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
