### PR TITLE
Cannot search by Client Patient ID in Sample Add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #162 Unable to search by Client Patient ID in Sample Add form
 - #159 Ensure `Client` contents allow to hold `Patient` types
 - #158 Fix the filter query in the Add Sample Form
 

--- a/bika/health/content/analysisrequest.py
+++ b/bika/health/content/analysisrequest.py
@@ -126,7 +126,7 @@ class AnalysisRequestSchemaExtender(object):
                          'secondary': 'disabled'},
                 catalog_name='bikahealth_catalog_patient_listing',
                 portal_types=('Patient',),
-                search_field='getClientPatientID',
+                search_fields=('getClientPatientID',),
                 base_query={'is_active': True,
                             'sort_limit': 50,
                             'sort_on': 'getClientPatientID',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Searches by Client Patient ID in Sample Add form return empty results.

## Current behavior before PR

Searches by Client Patient ID in Sample Add form return empty results.

## Desired behavior after PR is merged

Searches by Client Patient ID in Sample Add form return the list of patients with the typed Client Patient ID in the search box

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
