### PR TITLE
Cannot override Patients listing behavior with subscriber adapters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changelog
 
 **Changed**
 
+- #163 Cannot override behavior of Patients folder when using `before_render`
 - #157 Changed Base Catalog Tool
 
 

--- a/bika/health/browser/patients/folder_view.py
+++ b/bika/health/browser/patients/folder_view.py
@@ -122,10 +122,10 @@ class PatientsView(BikaListingView):
             },
         ]
 
-    def before_render(self):
+    def update(self):
         """Before template render hook
         """
-        super(PatientsView, self).before_render()
+        super(PatientsView, self).update()
 
         if IPatients.providedBy(self.context):
             self.request.set("disable_border", 1)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`PatientsView` is used as the "root" listing view for Patients listings. Since it overrides the function `before_render`, some of the changes made in subscriber adapters from another add-ons are omitted. For instance, trying to modify `self.context_actions` via subscriber adapters won't have any effect because after the call, the value is overrided in PatientsView.

This Pull Request moves the logic `before_render` from the base class `PatientsView` to the function `update`.

## Current behavior before PR

Cannot override some behavior (e.g., context_actions) of PatientsView listing by using subscriber adapters.

## Desired behavior after PR is merged

Can override behavior of PatientsView listing by using subscriber adapters.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
