### PR TITLE
Compatibility with core's PR1498

### DIFF
--- a/bika/health/upgrade/v01_02_003.py
+++ b/bika/health/upgrade/v01_02_003.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.health import DEFAULT_PROFILE_ID
 from bika.health import logger
 from bika.health.config import PROJECTNAME
 from bika.lims.upgrade import upgradestep
@@ -43,6 +44,7 @@ def upgrade(tool):
                                                    version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    setup.runImportStepFromProfile(DEFAULT_PROFILE_ID, "skins")
 
     logger.info("{0} upgraded to version {1}".format(PROJECTNAME, version))
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

core's upgrade v1.3.3 restores the skins order

## Current behavior before PR

After core's upgrade 1.3.3, health's order of skins is lost

## Desired behavior after PR is merged

After health's upgrade 1.2.3, health's order of skins is preserved

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
