### PR TITLE
Better handling of ClientPatientID and Patient fields in Add Sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #166 Better handling of ClientPatientID and Patient fields in Add Sample
 
 **Changed**
 

--- a/bika/health/adapters/addsample.py
+++ b/bika/health/adapters/addsample.py
@@ -195,6 +195,29 @@ class AddSampleBatchInfo(AddSampleObjectInfoAdapter):
             "title": obj and api.get_title(obj) or ""}
 
 
+class AddSamplePatientInfo(AddSampleObjectInfoAdapter):
+    """Returns the info metadata representation of a Patient object used in Add
+    Sample form
+    """
+    def get_object_info(self):
+        object_info = self.get_base_info()
+
+        # Default values for other fields when the Patient is selected
+        patient = self.context
+        field_values = {
+            "Patient": {
+                "uid": api.get_uid(patient),
+                "title": patient.getFullname(),
+            },
+            "ClientPatientID": {
+                "uid": api.get_uid(patient),
+                "title": patient.getClientPatientID() or "",
+            }
+        }
+        object_info["field_values"] = field_values
+        return object_info
+
+
 class AddSampleFieldsFlush(object):
     """Health-specific flush of fields for Sample Add form. When the value for
     Client field changes, flush the fields "Patient", "Doctor" and "Batch"
@@ -211,6 +234,12 @@ class AddSampleFieldsFlush(object):
                 "ClientPatientID",
                 "Doctor",
                 "Patient",
+            ],
+            "ClientPatientID": [
+                "Patient",
+            ],
+            "Patient": [
+                "ClientPatientID",
             ]
         }
         return flush_settings

--- a/bika/health/adapters/configure.zcml
+++ b/bika/health/adapters/configure.zcml
@@ -58,6 +58,13 @@
     provides="bika.lims.interfaces.IAddSampleObjectInfo"
     name="senaite.health.addsample_batch_info" />
 
+  <!-- Additional metadata for Patient field in Add Sample form -->
+  <adapter
+    factory=".addsample.AddSamplePatientInfo"
+    for="bika.health.interfaces.IPatient"
+    provides="bika.lims.interfaces.IAddSampleObjectInfo"
+    name="senaite.health.addsample_patient_info" />
+
   <!-- Flushing of custom fields for Add Sample form -->
   <adapter
     factory=".addsample.AddSampleFieldsFlush"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In Sample Add form with both "ClientPatientID" and "Patient" fields visible, user can choose different values for each one, even that the underlying object should be the same: Patient.

These two fields must work together. When a Patient is selected by using Client Patient ID, the Patient field must be populated with same value and the other way round.

## Current behavior before PR

ClientPatientID and Patient fields in Add Sample form do not work together

## Desired behavior after PR is merged

ClientPatientID and Patient fields in Add Sample form do work together

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
