### PR TITLE
Cannot create Patient inside Client (content type not allowed)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 
 **Fixed**
 
+- #168 Cannot create Patient inside Client (content type not allowed)
 - #162 Unable to search by Client Patient ID in Sample Add form
 - #159 Ensure `Client` contents allow to hold `Patient` types
 - #158 Fix the filter query in the Add Sample Form

--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -117,6 +117,10 @@ def post_install(portal_setup):
     # Setup default ethnicities
     setup_ethnicities(portal)
 
+    # Allow patients inside clients
+    # Note: this should always be run if core's typestool is reimported
+    allow_patients_inside_clients(portal)
+
     # Reindex the top level folder in the portal and setup to fix missing icons
     reindex_content_structure(portal)
 
@@ -453,3 +457,13 @@ def setup_panic_alerts(portal):
         "that may indicate an imminent life-threatening condition:\n\n"
         "${analyses}\n\n--\n${lab_address}")
     ploneapi.portal.set_registry_record("senaite.panic.email_body", email_body)
+
+
+def allow_patients_inside_clients(portal):
+    """Allows Patient content type to be created inside Client
+    """
+    portal_types = api.get_tool('portal_types')
+    client = getattr(portal_types, 'Client')
+    allowed_types = client.allowed_content_types
+    if 'Patient' not in allowed_types:
+        client.allowed_content_types = allowed_types + ('Patient', )

--- a/bika/health/subscribers/configure.zcml
+++ b/bika/health/subscribers/configure.zcml
@@ -1,12 +1,6 @@
 <configure xmlns="http://namespaces.zope.org/zope"
            i18n_domain="senaite.core">
 
-  <!-- Patient creation. Allow to create Patient content types inside Client -->
-  <subscriber
-    for="bika.health.interfaces.IPatient
-         zope.lifecycleevent.interfaces.IObjectCreatedEvent"
-    handler=".patient.ObjectCreatedEventHandler" />
-
   <!-- Patient modification. If the patient has a client assigned, this event
    moves the Patient into the Client's folder -->
   <subscriber

--- a/bika/health/subscribers/patient.py
+++ b/bika/health/subscribers/patient.py
@@ -22,24 +22,10 @@ from bika.lims import api
 from bika.lims.api import security
 
 
-def ObjectCreatedEventHandler(patient, event):
-    # Ensure Clients can contain Patients. Doing this here we guarantee that
-    # Patients are allowed content types even if the types tool is reloaded in
-    # senaite.core due to an upgrade step
-    # https://github.com/senaite/senaite.health/pull/159
-    allow_patients_inside_clients()
-
-
 def ObjectModifiedEventHandler(patient, event):
     """Actions to be done when a patient is modified. Moves the Patient to
     Client folder if assigned
     """
-    # Ensure Clients can contain Patients. Doing this here we guarantee that
-    # Patients are allowed content types even if the types tool is reloaded in
-    # senaite.core due to an upgrade step
-    # https://github.com/senaite/senaite.health/pull/159
-    allow_patients_inside_clients()
-
     # If client is assigned, move the Patient to the Client's folder
     # Note here we get the Client directly from the Schema, cause
     # getPrimaryReferrer is overriden in Patient content type to always look to
@@ -52,16 +38,6 @@ def ObjectModifiedEventHandler(patient, event):
         # Move the Patient inside the client
         cp = patient.aq_parent.manage_cutObjects(patient.id)
         client.manage_pasteObjects(cp)
-
-
-def allow_patients_inside_clients():
-    """Adds Patient content type to the list of allowed objects inside Client
-    """
-    portal_types = api.get_tool("portal_types")
-    client_fti = portal_types.getTypeInfo("Client")
-    allowed_types = client_fti.allowed_content_types
-    if "Patient" not in allowed_types:
-        client_fti.allowed_content_types = allowed_types + ("Patient", )
 
 
 # TODO: This is no longer needed!

--- a/bika/health/upgrade/v01_02_002.py
+++ b/bika/health/upgrade/v01_02_002.py
@@ -31,6 +31,7 @@ from zope.lifecycleevent import ObjectMovedEvent
 from bika.health import CATALOG_PATIENTS
 from bika.health import logger
 from bika.health.config import PROJECTNAME
+from bika.health.setuphandlers import allow_patients_inside_clients
 from bika.lims import api
 from bika.lims.catalog.bika_catalog import BIKA_CATALOG
 from bika.lims.idserver import renameAfterCreation
@@ -192,11 +193,7 @@ def move_patients_to_clients(portal):
     workflow = wf_tool.getWorkflowById("senaite_health_patient_workflow")
 
     # Allow Patient content type inside Clients
-    portal_types = api.get_tool('portal_types')
-    client = getattr(portal_types, 'Client')
-    allowed_types = client.allowed_content_types
-    if 'Patient' not in allowed_types:
-        client.allowed_content_types = allowed_types + ('Patient',)
+    allow_patients_inside_clients(portal)
 
     # Map patient uids against batches' clients
     patients_to_clients = dict()

--- a/bika/health/upgrade/v01_02_003.py
+++ b/bika/health/upgrade/v01_02_003.py
@@ -22,6 +22,7 @@ from bika.health import api
 from bika.health import DEFAULT_PROFILE_ID
 from bika.health import logger
 from bika.health.config import PROJECTNAME
+from bika.health.setuphandlers import allow_patients_inside_clients
 from bika.health.setuphandlers import setup_panic_alerts
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.upgrade import upgradestep
@@ -57,6 +58,10 @@ def upgrade(tool):
     # Update Sample's PanicEmailAlertSent field
     # https://github.com/senaite/senaite.health/pull/161
     update_sample_panic_alert_field(portal)
+
+    # Allow Patient content type inside Client
+    # Note: this should always be run if core's typestool is reimported
+    allow_patients_inside_clients(portal)
     
     logger.info("{0} upgraded to version {1}".format(PROJECTNAME, version))
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

User cannot create Patient objects inside Client (by assigning the Client to the Patient)

Linked issue: https://github.com/senaite/senaite.health/issues/167

## Current behavior before PR

```
Traceback (innermost last):
Module ZPublisher.Publish, line 138, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module Products.CMFFormController.FSControllerPageTemplate, line 91, in call
Module Products.CMFFormController.BaseControllerPageTemplate, line 29, in _call
Module Products.CMFFormController.ControllerBase, line 232, in getNext
Module Products.CMFFormController.Actions.TraverseTo, line 38, in call
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module Products.CMFFormController.FSControllerPythonScript, line 105, in call
Module Products.CMFFormController.Script, line 145, in call
Module Products.CMFCore.FSPythonScript, line 127, in call
Module Shared.DC.Scripts.Bindings, line 322, in call
Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
Module Products.PythonScripts.PythonScript, line 344, in _exec
Module script, line 1, in content_edit

    <FSControllerPythonScript at /chimera/patients/P000001/content_edit>
    Line 1
    Module Products.CMFCore.FSPythonScript, line 127, in call
    Module Shared.DC.Scripts.Bindings, line 322, in call
    Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
    Module Products.PythonScripts.PythonScript, line 344, in _exec
    Module script, line 12, in content_edit_impl
    <FSPythonScript at /chimera/patients/P000001/content_edit_impl>
    Line 12
    Module Products.Archetypes.BaseObject, line 645, in processForm
    Module zope.event, line 31, in notify
    Module zope.component.event, line 24, in dispatch
    Module zope.component._api, line 136, in subscribers
    Module zope.component.registry, line 321, in subscribers
    Module zope.interface.adapter, line 585, in subscribers
    Module zope.component.event, line 32, in objectEventNotify
    Module zope.component._api, line 136, in subscribers
    Module zope.component.registry, line 321, in subscribers
    Module zope.interface.adapter, line 585, in subscribers
    Module bika.health.subscribers.patient, line 40, in ObjectModifiedEventHandler
    Module OFS.CopySupport, line 332, in manage_pasteObjects
    Module OFS.CopySupport, line 208, in _pasteObjects
    Module Products.CMFCore.PortalFolder, line 421, in _verifyObjectPaste
    ValueError: Disallowed subobject type: Patient
```

## Desired behavior after PR is merged

Patient objects can be created inside Client

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
