### PR TITLE
Fix sporadical errors when contacts do not have a valid email address

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,9 +17,11 @@ Changelog
 
 **Removed**
 
+- #170 Removal of stale javascripts and css
 
 **Fixed**
 
+- #172 Fix sporadical errors when contacts do not have a valid email address
 - #168 Cannot create Patient inside Client (content type not allowed)
 - #162 Unable to search by Client Patient ID in Sample Add form
 - #159 Ensure `Client` contents allow to hold `Patient` types

--- a/bika/health/upgrade/v01_02_003.py
+++ b/bika/health/upgrade/v01_02_003.py
@@ -17,7 +17,7 @@
 #
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
-
+from bika.health import CATALOG_PATIENTS
 from bika.health import api
 from bika.health import DEFAULT_PROFILE_ID
 from bika.health import logger
@@ -27,6 +27,7 @@ from bika.health.setuphandlers import setup_panic_alerts
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
+from bika.lims.upgrade.v01_03_003 import fix_email_address
 
 version = '1.2.3'
 profile = 'profile-{0}:default'.format(PROJECTNAME)
@@ -90,6 +91,10 @@ def upgrade(tool):
     # Remove stale css
     remove_stale_css(portal)
 
+    # Fix email addresses
+    # https://github.com/senaite/senaite.health/pulls/172
+    fix_health_email_addresses(portal)
+
     logger.info("{0} upgraded to version {1}".format(PROJECTNAME, version))
     return True
 
@@ -133,3 +138,18 @@ def remove_stale_css(portal):
     for css in CSS_TO_REMOVE:
         logger.info("Unregistering CSS %s" % css)
         portal.portal_css.unregisterResource(css)
+
+
+def fix_health_email_addresses(portal):
+    """Validates the email address for portal types that inherit from Person.
+    The field did not have an email validator, causing some views to fail when
+    rendering the value while expecting a valid email address format
+    """
+    # Fix email address for portal types from portal_catalog
+    portal_types = ["VaccinationCenterContact", "Doctor"]
+    fix_email_address(portal, portal_types=portal_types)
+
+    # Fix email address for portal types from other catalogs
+    portal_types = ["Patient"]
+    fix_email_address(portal, portal_types=portal_types,
+                      catalog_id=CATALOG_PATIENTS)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

User can set invalid email addresses for Patient, Doctor and other types that inherit from Person content type. This leads to sporadic errors in views or templates that expect valid email address format.

Merge https://github.com/senaite/senaite.core/pull/1542 first

## Current behavior before PR

User can assign invalid email addresses in "Email address" field from contacts

## Desired behavior after PR is merged

User cannot assign invalid email addresses in "Email address" field from contacts

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
