### PR TITLE
Install senaite.panic add-on in upgrade 1.3.2

### DIFF
--- a/bika/health/upgrade/v01_02_003.py
+++ b/bika/health/upgrade/v01_02_003.py
@@ -71,6 +71,9 @@ def upgrade(tool):
     # -------- ADD YOUR STUFF BELOW --------
     setup.runImportStepFromProfile(DEFAULT_PROFILE_ID, "skins")    
     setup.runImportStepFromProfile(DEFAULT_PROFILE_ID, "jsregistry")
+
+    # Install senaite.panic add-on if not yet installed
+    install_senaite_panic(portal)
     
     # Setup template text for panic level alert emails
     # https://github.com/senaite/senaite.health/pull/161
@@ -133,3 +136,18 @@ def remove_stale_css(portal):
     for css in CSS_TO_REMOVE:
         logger.info("Unregistering CSS %s" % css)
         portal.portal_css.unregisterResource(css)
+
+
+def install_senaite_panic(portal):
+    """Install the senaite.panic addon
+    """
+    qi = api.get_tool("portal_quickinstaller")
+    profile = "senaite.panic"
+    if profile not in qi.listInstallableProfiles():
+        logger.error("Profile '{}' not found. Forgot to run buildout?"
+                     .format(profile))
+        return
+    if qi.isProductInstalled(profile):
+        logger.info("'{}' is installed".format(profile))
+        return
+    qi.installProduct(profile)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Install `senaite.panic` add-on in upgrade step 1.3.2 if not yet installed

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1053, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module bika.lims.upgrade, line 68, in wrap_func_args
  Module bika.health.upgrade.v01_02_003, line 78, in upgrade
  Module bika.health.setuphandlers, line 459, in setup_panic_alerts
  Module plone.api.portal, line 2, in set_registry_record
  Module plone.api.validation, line 77, in wrapped
  Module plone.api.portal, line 392, in set_registry_record
  Module plone.api.portal, line 2, in get_registry_record
  Module plone.api.validation, line 77, in wrapped
  Module plone.api.portal, line 340, in get_registry_record
InvalidParameterError: Cannot find a record with name 'senaite.panic.email_body'
```

## Desired behavior after PR is merged

No traceback, `senaite.panic` installed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
