### PR TITLE
Pin Python 2.7 compatible versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,10 @@ setup(
         "senaite.lims>=1.3.1",
         "senaite.lims<2.0.0",
         "senaite.panic",
+        # Python 2.7 compatibility
+        #
+        # https://pypi.org/project/zipp
+        "zipp<2.0.0",
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Pin Python 2.7 compatible versions in `setup.py`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
