### PR TITLE
Fix traceback when calling getBatches from Patient

### DIFF
--- a/bika/health/content/patient.py
+++ b/bika/health/content/patient.py
@@ -1132,7 +1132,7 @@ class Patient(Person):
         query = dict(portal_type="Batch", getPatientUID=api.get_uid(self))
         batches = api.search(query, BIKA_CATALOG)
         if full_objects:
-            batches = map(api.get_object_by_uid, batches)
+            return map(api.get_object, batches)
         return batches
 
     def SearchableText(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback occurs when function `getBatches` from `Patient` is called with `full_objects` parameter set to `True`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
