### PR TITLE
Patient historic results are not displayed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog
 
 **Fixed**
 
+- #181 Patient historic results are not displayed
 - #172 Fix sporadical errors when contacts do not have a valid email address
 - #168 Cannot create Patient inside Client (content type not allowed)
 - #162 Unable to search by Client Patient ID in Sample Add form

--- a/bika/health/browser/patient/historicresults.pt
+++ b/bika/health/browser/patient/historicresults.pt
@@ -107,7 +107,7 @@
 
                         <!-- Link to Sample ID -->
                         <div class="row">
-                          <div class="col-sm-4">
+                          <div class="col-md-4">
                             <a class="small"
                                tal:define="an_obj python: an_date['object'];
                                            sample python: an_obj.aq_parent;"
@@ -116,7 +116,7 @@
                           </div>
 
                           <!-- Result -->
-                          <div class="col-sm-8">
+                          <div class="col-md-8">
                             <span tal:define="result python: an_date.get('formattedresult', '')"
                                   tal:content="structure result"/>
                             <!-- Units -->

--- a/bika/health/browser/patient/historicresults.pt
+++ b/bika/health/browser/patient/historicresults.pt
@@ -54,8 +54,8 @@
               <label for="interpolation">Interpolation</label>
               <select id="interpolation" name="interpolation">
                   <option value="linear" selected>linear</option>
-                  <option value="cardinal">cardinal</option>
                   <option value="basis">basis</option>
+                  <option value="cardinal">cardinal</option>
               </select>
           </div>
           <div id="chart"></div>

--- a/bika/health/browser/patient/historicresults.pt
+++ b/bika/health/browser/patient/historicresults.pt
@@ -5,11 +5,19 @@
     metal:use-macro="here/main_template/macros/master"
     i18n:domain="senaite.health">
 
-<metal:slot fill-slot="head_slot">
-    <style>
+  <head>
+    <metal:block fill-slot="javascript_head_slot">
+      <!-- Javascript that renders the D3js chart for historic results -->
+      <script tal:define="js string:${portal_url}/++resource++bika.health.js"
+              tal:attributes="src string:${js}/bika.health.historicresults.js"
+              type="text/javascript"></script>
+    </metal:block>
+
+    <metal:block fill-slot="style_slot">
+      <style>
         #chart {
             font-size:0.9em;
-            margin-bottom:15px;
+            overflow: hidden;
         }
         .axis path,
         .axis line {
@@ -17,244 +25,124 @@
           stroke: #000;
           shape-rendering: crispEdges;
         }
-
-        .x.axis path {
-          display: none;
+        .analysis-keyword {
+          font-size:0.8em;
+          color:#333;
         }
+      </style>
+    </metal:block>
+  </head>
 
-        .line {
-          fill: none;
-          stroke: steelblue;
-          stroke-width: 1.5px;
-        }
-        .chart-container {
-            border: 1px solid #CDCDCD;
-            margin: 10px 0;
-            border-radius: 5px;
-        }
-        .chart-options {
-            padding:10px;
-            background: #DDDDDD;
-        }
-    </style>
-    <script src="http://d3js.org/d3.v3.js"></script>
-    <script>
-        jQuery(function($){
-    $(document).ready(function(){
-
-        $('div.chart-container #interpolation').change(function(e) {
-            loadChart($(this).val());
-        });
-
-        loadChart('cardinal');
-
-
-        function loadChart(interpolation) {
-            if ($("#chart svg").length > 0) {
-                $("#chart").css('height', $("#chart").innerHeight());
-                $("#chart").css('width', $("#chart").innerWidth());
-            }
-            $("#chart").html("");
-
-            d3.json("historicjson", function(error, data) {
-                if (error || data.length < 2) {
-                    $(".chart-container").hide();
-                    return;
-                }
-                $(".chart-container").show();
-                var margin = {top: 20, right: 120, bottom: 30, left: 50},
-                    width = $('#chart').innerWidth() - margin.left - margin.right,
-                    height = 250 - margin.top - margin.bottom;
-
-                var parseDate = d3.time.format("%Y-%m-%d %H:%M %p").parse;
-
-                var x = d3.time.scale()
-                    .range([0, width]);
-
-                var y = d3.scale.linear()
-                    .range([height, 0]);
-
-                var color = d3.scale.category10();
-
-                var xAxis = d3.svg.axis()
-                    .scale(x)
-                    .orient("bottom");
-
-                var yAxis = d3.svg.axis()
-                    .scale(y)
-                    .orient("left");
-
-                var line = d3.svg.line()
-                    .interpolate(interpolation)
-                    .x(function(d) { return x(d.date); })
-                    .y(function(d) { return y(d.result); });
-
-                $('#chart').append('<svg></svg>');
-                var svg = d3.select("svg")
-                    .attr("width", width + margin.left + margin.right)
-                    .attr("height", height + margin.top + margin.bottom)
-                  .append("g")
-                    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
-
-                color.domain(d3.keys(data[0]).filter(function(key) { return key !== "date"; }));
-                data.forEach(function(d) {
-                    d.date = parseDate(d.date);
-                });
-
-                var series = color.domain().map(function(name) {
-                    return {
-                      name: name,
-                      values: data.map(function(d) {
-                        return {date: d.date, result: +d[name]};
-                      })
-                    };
-                });
-
-                x.domain(d3.extent(data, function(d) { return d.date; }));
-
-                y.domain([
-                    d3.min(series, function(c) { return d3.min(c.values, function(v) { return v.result; }); }),
-                    d3.max(series, function(c) { return d3.max(c.values, function(v) { return v.result; }); })
-                ]);
-
-                svg.append("g")
-                  .attr("class", "x axis")
-                  .attr("transform", "translate(0," + height + ")")
-                  .call(xAxis);
-
-                svg.append("g")
-                  .attr("class", "y axis")
-                  .call(yAxis)
-                .append("text")
-                  .attr("transform", "rotate(-90)")
-                  .attr("y", 6)
-                  .attr("dy", ".71em")
-                  .style("text-anchor", "end")
-                  .text("Result");
-
-                var serie = svg.selectAll(".serie")
-                  .data(series)
-                .enter().append("g")
-                  .attr("class", "serie");
-
-                serie.append("path")
-                  .attr("class", "line")
-                  .attr("d", function(d) { return line(d.values); })
-                  .style("stroke", function(d) { return color(d.name); });
-
-                serie.append("text")
-                  .datum(function(d) { return {name: d.name, value: d.values[d.values.length - 1]}; })
-                  .attr("transform", function(d) { return "translate(" + x(d.value.date) + "," + y(d.value.result) + ")"; })
-                  .attr("x", 10)
-                  .attr("dy", ".35em")
-                  .text(function(d) { return d.name; });
-
-                series.forEach(function(d) {
-                    res = d.results;
-                    vals = d.values;
-                    col = color(d.name);
-                    vals.forEach(function(v) {
-                        svg.append("circle")
-                          .attr("r", 4)
-                          .style("fill", col)
-                          .attr("cx", x(v.date))
-                          .attr("cy", y(v.result))
-                       /* svg.append("text")
-                          .attr("x", x(v.date)-5)
-                          .attr("dy", y(v.result)-5)
-                          .text(parseFloat(v.result).toFixed(2))*/
-
-                    });
-                });
-            });
-
-        }
-    });
-});
-    </script>
-</metal:slot>
-<body>
+  <body>
     <metal:content-title fill-slot="content-title">
-        <h1>
-            <img tal:condition="view/icon | nothing"
-                 tal:attributes="src view/icon"/>
-            <span style="position:relative;top:-0.2em;"
-                  class="documentFirstHeading"
-                  tal:content="view/title"/>
-        </h1>
+      <h1>
+        <img tal:condition="view/icon | nothing"
+             tal:attributes="src view/icon"/>
+        <span class="documentFirstHeading" tal:content="view/title"/>
+      </h1>
     </metal:content-title>
 
-    <metal:content-description fill-slot="content-description">
-        <div class="documentDescription"
-             tal:content="structure view/description"
-             tal:condition="view/description"/>
-    </metal:content-description>
+    <metal:block fill-slot="content-description">
+      <div class="documentDescription"
+           tal:condition="view/description"
+           tal:content="structure view/description"></div>
+    </metal:block>
 
     <metal:content-core fill-slot="content-core">
-        <div class='chart-container'>
-            <div class='chart-options'>
-                <label for='interpolation'>Interpolation</label>
-                <select id='interpolation' name='interpolation'>
-                    <option value='cardinal' selected>cardinal</option>
-                    <option value='basis'>basis</option>
-                    <option value='linear'>linear</option>
-                </select>
-            </div>
-            <div id='chart'></div>
+
+      <!-- Chart container -->
+      <div class="chart-container">
+          <div class="chart-options">
+              <label for="interpolation">Interpolation</label>
+              <select id="interpolation" name="interpolation">
+                  <option value="cardinal" selected>cardinal</option>
+                  <option value="basis">basis</option>
+                  <option value="linear">linear</option>
+              </select>
+          </div>
+          <div id="chart"></div>
+      </div>
+
+      <!-- Table of historic results -->
+      <tal:historic_table define="dates python:view.get_dates()">
+        <div tal:condition="python:len(dates)!=0">
+          <table class=" table table-condensed small"
+              tal:define="rows python:view.get_rows();
+                          cols python:len(dates)+2;">
+            <thead>
+              <tr>
+                <th i18n:translate="">Test</th>
+                <tal:datecols repeat="date dates">
+                  <th tal:content="python:date" class="center"/>
+                </tal:datecols>
+                <th i18n:translate="">Units</th>
+              </tr>
+            </thead>
+
+            <tbody class="item-listing-body">
+              <!-- Group by sample types -->
+              <tal:sampletypes repeat="row python:rows.itervalues()">
+                <tr tal:define="sample_type python: row['object'];
+                                sample_type_title python: sample_type.Title()">
+                  <th tal:attributes="colspan python:cols;
+                                      cat python:sample_type_title"
+                      tal:content="python: sample_type_title"
+                      class="cat_header expanded"/>
+                </tr>
+
+                <!-- Generate as many rows as analyses for this sample type -->
+                <tal:analyses repeat="analysis python:row['analyses'].itervalues()">
+                  <tr tal:attributes="cat python:row['object'].Title()">
+                    <td>
+                      <span class="analysis-title"
+                            tal:content="python:analysis['title']"/>&nbsp;
+                      <span class="analysis-keyword"
+                            tal:content="python:'({})'.format(analysis['keyword'])"/>
+                    </td>
+
+                    <!-- Generate as many columns as dates -->
+                    <tal:rowdates repeat="date dates">
+
+                      <!-- There is an analysis with result for this date -->
+                      <td tal:define="an_date python: analysis.get(date, {})"
+                          tal:condition="python: an_date">
+
+                        <!-- Link to Sample ID -->
+                        <div class="col-sm-6">
+                          <a class="small"
+                             tal:define="an_obj python: an_date['object'];
+                                         sample python: an_obj.aq_parent;"
+                             tal:attributes="href python: sample.absolute_url()"
+                             tal:content="python: sample.id"/>
+                        </div>
+
+                        <!-- Result -->
+                        <div class="col-sm-6">
+                          <span tal:define="result python: an_date.get('formattedresult', '')"
+                                tal:content="structure result"/>
+                        </div>
+                      </td>
+
+                      <!-- There is no analysis with result for this date -->
+                      <td tal:define="an_date python: analysis.get(date, {})"
+                          tal:condition="python: not an_date"/>
+
+                    </tal:rowdates>
+
+                    <!-- Units -->
+                    <td tal:content="python:analysis['units']" />
+                  </tr>
+                </tal:analyses>
+              </tal:sampletypes>
+            </tbody>
+          </table>
         </div>
-        <tal:historictable define='dates python:view.get_dates()'>
-        <div class='bika-listing-table-container'
-             tal:condition='python:len(dates)!=0'>
-            <table tal:define="rows python:view.get_rows();
-                           cols python:len(dates)+3;"
-                   class='bika-listing-table'>
-                <thead>
-                    <tr>
-                        <th i18n:translate="">Test</th>
-                        <tal:datecols repeat="date dates">
-                        <th tal:content="python:date" class='center'></th>
-                        </tal:datecols>
-                        <th i18n:translate="">Units</th>
-                        <th i18n:translate="">Range</th>
-                    </tr>
-                </thead>
-                <tbody class='item-listing-body'>
-                    <tal:sampletypes repeat="row python:rows.itervalues()">
-                    <tr>
-                        <th tal:attributes="colspan python:cols;
-                                            cat python:row['object'].Title();"
-                            tal:content="python:row['object'].Title()"
-                            class="cat_header expanded"></th>
-                    </tr>
-                    <tal:analyses repeat="analysis python:row['analyses'].itervalues()">
-                    <tr tal:attributes="cat python:row['object'].Title()">
-                        <td>
-                            <span tal:content="python:analysis['title']"/>&nbsp;
-                            <span style="font-size:0.8em;color:#333;" tal:content="python:' ('+analysis['keyword']+')'"/>
-                        </td>
-                        <tal:rowdates repeat="date dates">
-			<td tal:condition="python:analysis.get(date,None)"> 
-			  <span tal:content="python:analysis.get(date,{}).get('formattedresult', '')" class='center'/> - 
-			  <a href="" tal:attributes="href python:analysis.get(date,{}).get('object','').aq_parent.absolute_url()">
-			    <span tal:content="python:analysis.get(date,{}).get('object','').aq_parent.id" class='center'/> 
-			  </a>
-			</td>
-			<td tal:condition="python:not analysis.get(date,None)"></td>
-                        </tal:rowdates>
-                        <td tal:content="python:analysis['units']"></td>
-                        <td tal:content="python:analysis['specs'].get('rangecomment','')"></td>
-                    </tr>
-                    </tal:analyses>
-                    </tal:sampletypes>
-                </tbody>
-            </table>
+        <div tal:condition="python:len(dates)==0">
+          <dl class="portalMessage">
+              <dd i18n:translate="">No historic results found</dd>
+          </dl>
         </div>
-        <div tal:condition='python:len(dates)==0'>
-            <dl class="portalMessage">
-                <dd i18n:translate="">No historic results found</dd>
-            </dl>
-        </div>
-        </tal:historictable>
+      </tal:historic_table>
     </metal:content-core>
-</body>
+  </body>
 </html>

--- a/bika/health/browser/patient/historicresults.pt
+++ b/bika/health/browser/patient/historicresults.pt
@@ -66,14 +66,13 @@
         <div tal:condition="python:len(dates)!=0">
           <table class=" table table-condensed small"
               tal:define="rows python:view.get_rows();
-                          cols python:len(dates)+2;">
+                          cols python:len(dates)+1;">
             <thead>
               <tr>
                 <th i18n:translate="">Test</th>
                 <tal:datecols repeat="date dates">
                   <th tal:content="python:date" class="center"/>
                 </tal:datecols>
-                <th i18n:translate="">Units</th>
               </tr>
             </thead>
 
@@ -92,9 +91,11 @@
                 <tal:analyses repeat="analysis python:row['analyses'].itervalues()">
                   <tr tal:attributes="cat python:row['object'].Title()">
                     <td>
-                      <span tal:content="python:analysis['title']"/>&nbsp;
+                      <!-- Test code/keyword -->
                       <span class="small"
-                            tal:content="python:'({})'.format(analysis['keyword'])"/>
+                            tal:content="python: analysis['keyword']"/>:&nbsp;
+                      <!-- Test name -->
+                      <span tal:content="python: analysis['title']"/>
                     </td>
 
                     <!-- Generate as many columns as dates -->
@@ -105,18 +106,25 @@
                           tal:condition="python: an_date">
 
                         <!-- Link to Sample ID -->
-                        <div class="col-sm-6">
-                          <a class="small"
-                             tal:define="an_obj python: an_date['object'];
-                                         sample python: an_obj.aq_parent;"
-                             tal:attributes="href python: sample.absolute_url()"
-                             tal:content="python: sample.id"/>
-                        </div>
+                        <div class="row">
+                          <div class="col-sm-4">
+                            <a class="small"
+                               tal:define="an_obj python: an_date['object'];
+                                           sample python: an_obj.aq_parent;"
+                               tal:attributes="href python: sample.absolute_url()"
+                               tal:content="python: sample.id"/>
+                          </div>
 
-                        <!-- Result -->
-                        <div class="col-sm-6">
-                          <span tal:define="result python: an_date.get('formattedresult', '')"
-                                tal:content="structure result"/>
+                          <!-- Result -->
+                          <div class="col-sm-8">
+                            <span tal:define="result python: an_date.get('formattedresult', '')"
+                                  tal:content="structure result"/>
+                            <!-- Units -->
+                            <span
+                                tal:define="units python: analysis['units']"
+                                tal:condition="units"
+                                tal:content="structure python: ' {}'.format(units)"/>
+                          </div>
                         </div>
                       </td>
 
@@ -125,9 +133,6 @@
                           tal:condition="python: not an_date"/>
 
                     </tal:rowdates>
-
-                    <!-- Units -->
-                    <td tal:content="python:analysis['units']" />
                   </tr>
                 </tal:analyses>
               </tal:sampletypes>

--- a/bika/health/browser/patient/historicresults.pt
+++ b/bika/health/browser/patient/historicresults.pt
@@ -20,7 +20,6 @@
           overflow: hidden;
         }
         .chart-container {
-          display:none;
         }
         .axis path,
         .axis line {
@@ -54,9 +53,9 @@
           <div class="chart-options">
               <label for="interpolation">Interpolation</label>
               <select id="interpolation" name="interpolation">
-                  <option value="cardinal" selected>cardinal</option>
+                  <option value="linear" selected>linear</option>
+                  <option value="cardinal">cardinal</option>
                   <option value="basis">basis</option>
-                  <option value="linear">linear</option>
               </select>
           </div>
           <div id="chart"></div>

--- a/bika/health/browser/patient/historicresults.pt
+++ b/bika/health/browser/patient/historicresults.pt
@@ -16,18 +16,17 @@
     <metal:block fill-slot="style_slot">
       <style>
         #chart {
-            font-size:0.9em;
-            overflow: hidden;
+          font-size:0.9em;
+          overflow: hidden;
+        }
+        .chart-container {
+          display:none;
         }
         .axis path,
         .axis line {
           fill: none;
           stroke: #000;
           shape-rendering: crispEdges;
-        }
-        .analysis-keyword {
-          font-size:0.8em;
-          color:#333;
         }
       </style>
     </metal:block>
@@ -94,9 +93,8 @@
                 <tal:analyses repeat="analysis python:row['analyses'].itervalues()">
                   <tr tal:attributes="cat python:row['object'].Title()">
                     <td>
-                      <span class="analysis-title"
-                            tal:content="python:analysis['title']"/>&nbsp;
-                      <span class="analysis-keyword"
+                      <span tal:content="python:analysis['title']"/>&nbsp;
+                      <span class="small"
                             tal:content="python:'({})'.format(analysis['keyword'])"/>
                     </td>
 

--- a/bika/health/browser/patient/historicresults.py
+++ b/bika/health/browser/patient/historicresults.py
@@ -36,8 +36,8 @@ from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 
 
 class HistoricResultsView(BrowserView):
-    implements(IViewView)
-
+    """Historic Results View
+    """
     template = ViewPageTemplateFile("historicresults.pt")
 
     def __init__(self, context, request):

--- a/bika/health/browser/patient/historicresults.py
+++ b/bika/health/browser/patient/historicresults.py
@@ -24,8 +24,6 @@ from datetime import datetime
 
 from Products.ATContentTypes.utils import DT2dt
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from plone.app.layout.globals.interfaces import IViewView
-from zope.interface import implements
 
 from bika.health import bikaMessageFactory as _
 from bika.lims import api

--- a/bika/health/browser/patient/historicresults.py
+++ b/bika/health/browser/patient/historicresults.py
@@ -182,6 +182,8 @@ class historicResultsJSON(BrowserView):
             for row in data.itervalues():
                 for anrow in row['analyses'].itervalues():
                     serie = anrow['title']
+                    if "result" not in anrow.get(andate, {}):
+                        continue
                     datarow[serie] = anrow.get(andate, {}).get('result', '')
             datatable.append(datarow)
         return json.dumps(datatable)

--- a/bika/health/browser/patient/historicresults.py
+++ b/bika/health/browser/patient/historicresults.py
@@ -96,7 +96,7 @@ def get_historicresults(patient):
     # Retrieve the AR IDs for the current patient
     query = {"portal_type": "AnalysisRequest",
              "getPatientUID": api.get_uid(patient),
-             #"review_state": ["verified", "published"],
+             "review_state": ["verified", "published"],
              "sort_on": "getDateSampled",
              "sort_order": "descending"}
     brains = api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING)

--- a/bika/health/browser/patient/historicresults.py
+++ b/bika/health/browser/patient/historicresults.py
@@ -32,7 +32,6 @@ from bika.lims import api
 from bika.lims.api import to_date
 from bika.lims.api.analysis import get_formatted_interval
 from bika.lims.browser import BrowserView
-from bika.lims.browser import ulocalized_time
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 
 
@@ -134,7 +133,7 @@ def get_historicresults(patient):
 
         date = analysis.getResultCaptureDate() or analysis.created()
         date_time = DT2dt(to_date(date)).replace(tzinfo=None)
-        date_time = datetime.strftime(date_time, "%Y-%m-%d %H:%M:%S")
+        date_time = datetime.strftime(date_time, "%Y-%m-%d %H:%M")
 
         # If more than one analysis of the same type has been
         # performed in the same datetime, get only the last one

--- a/bika/health/browser/patient/historicresults.py
+++ b/bika/health/browser/patient/historicresults.py
@@ -27,10 +27,12 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 from bika.health import bikaMessageFactory as _
 from bika.lims import api
+from bika.lims import to_utf8
 from bika.lims.api import to_date
 from bika.lims.api.analysis import get_formatted_interval
 from bika.lims.browser import BrowserView
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
+from bika.lims.utils import format_supsub
 
 
 class HistoricResultsView(BrowserView):
@@ -123,11 +125,15 @@ def get_historicresults(patient):
         asdict = {
             "object": analysis,
             "title": api.get_title(analysis),
-            "keyword": analysis.getKeyword(),
-            "units": analysis.getUnit(),
+            "keyword": to_utf8(analysis.getKeyword()),
         }
         if service_uid in anrow:
             asdict = anrow.get(service_uid)
+
+        if not anrow.get("units", None):
+            asdict.update({
+                "units": format_supsub(to_utf8(analysis.getUnit()))
+            })
 
         date = analysis.getResultCaptureDate() or analysis.created()
         date_time = DT2dt(to_date(date)).replace(tzinfo=None)

--- a/bika/health/static/js/bika.health.historicresults.js
+++ b/bika/health/static/js/bika.health.historicresults.js
@@ -6,126 +6,176 @@ jQuery(function($){
       loadChart($(this).val());
     });
 
-    // By default, use "cardinal" interpolation
-    loadChart('cardinal');
+    // By default, use "linear" interpolation
+    loadChart("linear");
 
     function loadChart(interpolation) {
       if ($("#chart svg").length > 0) {
-          $("#chart").css('height', $("#chart").innerHeight());
-          $("#chart").css('width', $("#chart").innerWidth());
+        $("#chart").css("height", $("#chart").innerHeight());
+        $("#chart").css("width", $("#chart").innerWidth());
       }
 
       $("#chart").html("");
 
       d3.json("historicjson", function(error, data) {
+
+        // Do not display the chart if less than two results
         if (error || data.length < 2) {
-            $(".chart-container").hide();
-            return;
+          $(".chart-container").hide();
+          return;
         }
+
         $(".chart-container").show();
+
         var margin = {top: 20, right: 120, bottom: 30, left: 50},
-            width = $('#chart').innerWidth() - margin.left - margin.right,
-            height = 250 - margin.top - margin.bottom;
+          width = $('#chart').innerWidth() - margin.left - margin.right,
+          height = 250 - margin.top - margin.bottom;
 
-        var parseDate = d3.time.format("%Y-%m-%d %H:%M %p").parse;
-
-        var x = d3.time.scale()
-            .range([0, width]);
-
-        var y = d3.scale.linear()
-            .range([height, 0]);
+        var parse_date = d3.time.format("%Y-%m-%d %H:%M").parse;
 
         var color = d3.scale.category10();
 
+        var x = d3.time.scale()
+          .range([0, width]);
+
+        var y = d3.scale.linear()
+          .range([height, 0]);
+
         var xAxis = d3.svg.axis()
-            .scale(x)
-            .orient("bottom");
+          .scale(x)
+          .orient("bottom")
+          .tickSize(0);
 
         var yAxis = d3.svg.axis()
-            .scale(y)
-            .orient("left");
+          .scale(y)
+          .orient("left")
+          .tickSize(0);
 
         var line = d3.svg.line()
-            .interpolate(interpolation)
-            .x(function(d) { return x(d.date); })
-            .y(function(d) { return y(d.result); });
+          .interpolate(interpolation)
+          .x(function(d) { return x(d.date); })
+          .y(function(d) { return y(d.result); });
 
         $('#chart').append('<svg></svg>');
         var svg = d3.select("svg")
-            .attr("width", width + margin.left + margin.right)
-            .attr("height", height + margin.top + margin.bottom)
+          .attr("width", width + margin.left + margin.right)
+          .attr("height", height + margin.top + margin.bottom)
           .append("g")
-            .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+          .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
-        color.domain(d3.keys(data[0]).filter(function(key) { return key !== "date"; }));
+        color.domain(
+          d3.keys(data[0])
+            .filter(function(key) { return key !== "date"; }));
+
         data.forEach(function(d) {
-            d.date = parseDate(d.date);
+          d.date = parse_date(d.date);
         });
 
         var series = color.domain().map(function(name) {
-            return {
-              name: name,
-              values: data.map(function(d) {
-                return {date: d.date, result: +d[name]};
-              })
-            };
+          return {
+            name: name,
+            values: data.map(function(d) {
+              return {date: d.date, result: +d[name]};
+            })
+          };
         });
 
         x.domain(d3.extent(data, function(d) { return d.date; }));
-
         y.domain([
-            d3.min(series, function(c) { return d3.min(c.values, function(v) { return v.result; }); }),
-            d3.max(series, function(c) { return d3.max(c.values, function(v) { return v.result; }); })
+          d3.min(series, function(c) {
+            return d3.min(c.values, function(v) {
+              return v.result;
+            });
+          }),
+          d3.max(series, function(c) {
+            return d3.max(c.values, function(v) {
+              return v.result;
+            });
+          })
         ]);
 
         svg.append("g")
           .attr("class", "x axis")
+          .attr("fill", "#3f3f3f")
+          .style("font-size", "11px")
           .attr("transform", "translate(0," + height + ")")
-          .call(xAxis);
+          .call(xAxis)
+            .append("text")
+              .attr("x", width)
+              .attr("dy", "-0.71em")
+              .attr("text-anchor", "end")
+              .text("Date captured");
 
         svg.append("g")
           .attr("class", "y axis")
+          .attr("fill", "#3f3f3f")
+          .style("font-size", "11px")
           .call(yAxis)
-        .append("text")
-          .attr("transform", "rotate(-90)")
-          .attr("y", 6)
-          .attr("dy", ".71em")
-          .style("text-anchor", "end")
-          .text("Result");
+          .append("text")
+            .attr("transform", "rotate(-90)")
+            .attr("y", 6)
+            .attr("dy", ".71em")
+            .style("text-anchor", "end")
+            .text("Result");
 
         var serie = svg.selectAll(".serie")
           .data(series)
-        .enter().append("g")
+          .enter().append("g")
           .attr("class", "serie");
 
         serie.append("path")
           .attr("class", "line")
+          .attr("fill", "none")
           .attr("d", function(d) { return line(d.values); })
-          .style("stroke", function(d) { return color(d.name); });
+          .attr("stroke-width", "1.5px")
+          .style("stroke", function(d) { return color(d.name); })
+          .on("mouseout", function() {
+            d3.select(this)
+              .attr("stroke-width", "1.5px");
+          })
+          .on("mouseover",  function() {
+            d3.select(this)
+              .attr("stroke-width", "4px");
+          });
 
         serie.append("text")
           .datum(function(d) { return {name: d.name, value: d.values[d.values.length - 1]}; })
           .attr("transform", function(d) { return "translate(" + x(d.value.date) + "," + y(d.value.result) + ")"; })
           .attr("x", 10)
           .attr("dy", ".35em")
+          .style("font-size", "11px")
+          .style("fill", function(d) { return color(d.name);})
           .text(function(d) { return d.name; });
 
         series.forEach(function(d) {
-            res = d.results;
-            vals = d.values;
-            col = color(d.name);
-            vals.forEach(function(v) {
-                svg.append("circle")
-                  .attr("r", 4)
-                  .style("fill", col)
-                  .attr("cx", x(v.date))
-                  .attr("cy", y(v.result))
-               /* svg.append("text")
-                  .attr("x", x(v.date)-5)
-                  .attr("dy", y(v.result)-5)
-                  .text(parseFloat(v.result).toFixed(2))*/
-
-            });
+          res = d.results;
+          vals = d.values;
+          col = color(d.name);
+          vals.forEach(function(v) {
+            svg.append("circle")
+              .attr("r", 3)
+              .style("fill", col)
+              .attr("cx", x(v.date))
+              .attr("cy", y(v.result))
+              .on("mouseout", function() {
+                last = this.parentNode.children.length;
+                d3.select(this)
+                  .attr("r", 3);
+                d3.select(this.parentNode.children[last-1])
+                  .remove();
+              })
+              .on("mouseover",  function() {
+                d3.select(this)
+                  .attr("r", 6);
+                d3.select(this.parentNode)
+                  .append("text")
+                    .attr("fill", "#000000")
+                    .style("font-size", "11px")
+                    .attr("x", x(v.date) - 10)
+                    .attr("y", y(v.result) - 10)
+                    .text(v.result)
+              })
+          });
         });
       });
     }

--- a/bika/health/static/js/bika.health.historicresults.js
+++ b/bika/health/static/js/bika.health.historicresults.js
@@ -155,8 +155,21 @@ jQuery(function($){
               .attr("stroke-width", "4px");
           });
 
+        // Place the legend for the series
         serie.append("text")
-          .datum(function(d) { return {name: d.name, value: d.values[d.values.length - 1]}; })
+          .datum(function(d) {
+            // Get the last non empty value for this serie
+            var last_val = 0;
+            for (var i = d.values.length - 1; i >= 0; i--) {
+              var val = d.values[i];
+              console.log(val);
+              if (!Number.isNaN(val.result)) {
+                last_val = val;
+                break;
+              }
+            }
+            return {name: d.name, value: last_val};
+          })
           .attr("transform", function(d) { return "translate(" + x(d.value.date) + "," + y(d.value.result) + ")"; })
           .attr("x", 10)
           .attr("dy", ".35em")

--- a/bika/health/static/js/bika.health.historicresults.js
+++ b/bika/health/static/js/bika.health.historicresults.js
@@ -1,0 +1,134 @@
+jQuery(function($){
+  $(document).ready(function(){
+
+    // Update the chart when interpolation value changes
+    $('div.chart-container #interpolation').change(function(e) {
+      loadChart($(this).val());
+    });
+
+    // By default, use "cardinal" interpolation
+    loadChart('cardinal');
+
+    function loadChart(interpolation) {
+      if ($("#chart svg").length > 0) {
+          $("#chart").css('height', $("#chart").innerHeight());
+          $("#chart").css('width', $("#chart").innerWidth());
+      }
+
+      $("#chart").html("");
+
+      d3.json("historicjson", function(error, data) {
+        if (error || data.length < 2) {
+            $(".chart-container").hide();
+            return;
+        }
+        $(".chart-container").show();
+        var margin = {top: 20, right: 120, bottom: 30, left: 50},
+            width = $('#chart').innerWidth() - margin.left - margin.right,
+            height = 250 - margin.top - margin.bottom;
+
+        var parseDate = d3.time.format("%Y-%m-%d %H:%M %p").parse;
+
+        var x = d3.time.scale()
+            .range([0, width]);
+
+        var y = d3.scale.linear()
+            .range([height, 0]);
+
+        var color = d3.scale.category10();
+
+        var xAxis = d3.svg.axis()
+            .scale(x)
+            .orient("bottom");
+
+        var yAxis = d3.svg.axis()
+            .scale(y)
+            .orient("left");
+
+        var line = d3.svg.line()
+            .interpolate(interpolation)
+            .x(function(d) { return x(d.date); })
+            .y(function(d) { return y(d.result); });
+
+        $('#chart').append('<svg></svg>');
+        var svg = d3.select("svg")
+            .attr("width", width + margin.left + margin.right)
+            .attr("height", height + margin.top + margin.bottom)
+          .append("g")
+            .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+        color.domain(d3.keys(data[0]).filter(function(key) { return key !== "date"; }));
+        data.forEach(function(d) {
+            d.date = parseDate(d.date);
+        });
+
+        var series = color.domain().map(function(name) {
+            return {
+              name: name,
+              values: data.map(function(d) {
+                return {date: d.date, result: +d[name]};
+              })
+            };
+        });
+
+        x.domain(d3.extent(data, function(d) { return d.date; }));
+
+        y.domain([
+            d3.min(series, function(c) { return d3.min(c.values, function(v) { return v.result; }); }),
+            d3.max(series, function(c) { return d3.max(c.values, function(v) { return v.result; }); })
+        ]);
+
+        svg.append("g")
+          .attr("class", "x axis")
+          .attr("transform", "translate(0," + height + ")")
+          .call(xAxis);
+
+        svg.append("g")
+          .attr("class", "y axis")
+          .call(yAxis)
+        .append("text")
+          .attr("transform", "rotate(-90)")
+          .attr("y", 6)
+          .attr("dy", ".71em")
+          .style("text-anchor", "end")
+          .text("Result");
+
+        var serie = svg.selectAll(".serie")
+          .data(series)
+        .enter().append("g")
+          .attr("class", "serie");
+
+        serie.append("path")
+          .attr("class", "line")
+          .attr("d", function(d) { return line(d.values); })
+          .style("stroke", function(d) { return color(d.name); });
+
+        serie.append("text")
+          .datum(function(d) { return {name: d.name, value: d.values[d.values.length - 1]}; })
+          .attr("transform", function(d) { return "translate(" + x(d.value.date) + "," + y(d.value.result) + ")"; })
+          .attr("x", 10)
+          .attr("dy", ".35em")
+          .text(function(d) { return d.name; });
+
+        series.forEach(function(d) {
+            res = d.results;
+            vals = d.values;
+            col = color(d.name);
+            vals.forEach(function(v) {
+                svg.append("circle")
+                  .attr("r", 4)
+                  .style("fill", col)
+                  .attr("cx", x(v.date))
+                  .attr("cy", y(v.result))
+               /* svg.append("text")
+                  .attr("x", x(v.date)-5)
+                  .attr("dy", y(v.result)-5)
+                  .text(parseFloat(v.result).toFixed(2))*/
+
+            });
+        });
+      });
+    }
+
+  });
+});


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Patient historic results are not displayed in Patient's view

Linked issue: https://github.com/senaite/senaite.health/issues/113

## Current behavior before PR

Historic results are not displayed

## Desired behavior after PR is merged

Historic results chart with the results for analyses that are in verified or published results are displayed:

![Captura de 2020-04-03 23-25-01](https://user-images.githubusercontent.com/832627/78407517-50290100-7605-11ea-95af-49aadbe90387.png)




--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
