### PR TITLE
Prevent Traceback in patients listing when dob is not set

### DIFF
--- a/bika/health/browser/patients/folder_view.py
+++ b/bika/health/browser/patients/folder_view.py
@@ -166,10 +166,8 @@ class PatientsView(BikaListingView):
     def folderitem(self, obj, item, index):
         # Date of Birth
         dob = obj.getBirthDate
-        item['getBirthDate'] = self.ulocalized_time(dob)
-
-        # Patient's current age
-        item["age"] = get_age_ymd(dob)
+        item['getBirthDate'] = dob and self.ulocalized_time(dob) or ""
+        item["age"] = dob and get_age_ymd(dob) or ""
 
         # make the columns patient title, patient ID and client patient ID
         # redirect to the Analysis Requests of the patient


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixes the traceback explained here https://github.com/senaite/senaite.health/pull/180#discussion_r404860403

## Current behavior before PR

A traceback arises in Patients listing if the patient does not have a Date of Birth set

## Desired behavior after PR is merged

No traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
