### PR TITLE
Required patient data can be omitted on save causing errors on re-edit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Changelog
 
 **Fixed**
 
+- #184 Required patient data can be omitted on save causing error on re-edit
+
 **Security**
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull requests adds a proper notification when the Onset field from Past Medical History is not filled.

Linked issue: https://github.com/senaite/senaite.health/issues/185

## Current behavior before PR

When the user adds a record in Past Medical History (Patient), but without an Onset date, the item is saved, but user cannot edit the Patient record anymore until the missing Onset is filled and saved again.

## Desired behavior after PR is merged

System does not store past medical history records with onset date missing. The record is not saved and an error message is displayed insted

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
