### PR TITLE
Remove "classic" mode in folderitems

### DIFF
--- a/bika/health/browser/analysisrequests/view.py
+++ b/bika/health/browser/analysisrequests/view.py
@@ -62,8 +62,7 @@ class AnalysisRequestsView(BaseView):
             'title': _('Doctor'),
         }
 
-    def folderitems(self, full_objects=False):
-        logger.info("*** Bika Health's folderitems ***")
+    def folderitems(self):
         pm = getToolByName(self.context, "portal_membership")
         member = pm.getAuthenticatedMember()
         # We will use this list for each element
@@ -84,8 +83,7 @@ class AnalysisRequestsView(BaseView):
                 rs['columns'].insert(i, 'getPatientID')
                 rs['columns'].insert(i, 'getPatientTitle')
                 rs['columns'].insert(i, 'getDoctorTitle')
-        return super(AnalysisRequestsView, self).folderitems(
-            full_objects=False, classic=False)
+        return super(AnalysisRequestsView, self).folderitems()
 
     @viewcache.memoize
     def get_brain(self, uid, catalog):
@@ -98,8 +96,7 @@ class AnalysisRequestsView(BaseView):
         return None
 
     def folderitem(self, obj, item, index):
-        item = super(AnalysisRequestsView, self)\
-            .folderitem(obj, item, index)
+        item = super(AnalysisRequestsView, self).folderitem(obj, item, index)
 
         url = '{}/analysisrequests'.format(obj.getPatientURL)
         item['getPatientID'] = obj.getPatientID

--- a/bika/health/browser/doctors/folder_view.py
+++ b/bika/health/browser/doctors/folder_view.py
@@ -202,21 +202,17 @@ class DoctorsView(BikaListingView):
     def folderitem(self, obj, item, index):
         """Applies new properties to the item to be rendered
         """
-        try:
-            doctor = api.get_object(obj)
-        except:
-            return item
-
+        obj = api.get_object(obj)
         # Replace client name with the link
         item['getPrimaryReferrer'] = ""
-        client = doctor.getClient()
+        client = obj.getClient()
         if client:
             client_link = get_link(api.get_url(client), api.get_title(client))
             item["replace"]["getPrimaryReferrer"] = client_link
 
         # Replace doctor's full name with a link
         fullname = obj.getFullname()
-        doctor_url = "{}/analysisrequests".format(api.get_url(doctor))
+        doctor_url = "{}/analysisrequests".format(api.get_url(obj))
         doctor_link = get_link(doctor_url, fullname)
         item["replace"]["getFullname"] = doctor_link
         doctor_link = get_link(doctor_url, obj.getDoctorID())

--- a/bika/health/browser/insurancecompany/invoicefolder.py
+++ b/bika/health/browser/insurancecompany/invoicefolder.py
@@ -18,13 +18,16 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from plone.app.content.browser.interfaces import IFolderContentsView
 from Products.CMFCore.utils import getToolByName
+from zope.interface.declarations import implements
+
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.permissions import ManageInvoices
 from bika.lims.utils import currency_format
-from plone.app.content.browser.interfaces import IFolderContentsView
-from zope.interface.declarations import implements
+from bika.lims.utils import get_link
 
 """ This file contains an invoice type folder to be used in insurance company's stuff.
 """
@@ -108,24 +111,13 @@ class InvoiceFolderView(BikaListingView):
                 if patient and patient.getInsuranceCompany() else None
         return icuid == self.context.UID()
 
-    def folderitems(self, full_objects=False):
-        """
-        :return: All the invoices related with the Insurance Company's clients.
-        """
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
         currency = currency_format(self.context, 'en')
-        self.show_all = True
-        items = BikaListingView.folderitems(self, full_objects)
-        l = []
-        for item in items:
-            obj = item['obj']
-            number_link = "<a href='%s'>%s</a>" % (
-                item['url'], obj.getId()
-            )
-            item['replace']['id'] = number_link
-            item['client'] = obj.getClient().Title()
-            item['invoicedate'] = self.ulocalized_time(obj.getInvoiceDate())
-            item['subtotal'] = currency(obj.getSubtotal())
-            item['vatamount'] = currency(obj.getVATAmount())
-            item['total'] = currency(obj.getTotal())
-            l.append(item)
-        return l
+        item['replace']['id'] = get_link(item["url"], api.get_id(obj))
+        item['client'] = obj.getClient().Title()
+        item['invoicedate'] = self.ulocalized_time(obj.getInvoiceDate())
+        item['subtotal'] = currency(obj.getSubtotal())
+        item['vatamount'] = currency(obj.getVATAmount())
+        item['total'] = currency(obj.getTotal())
+        return item

--- a/bika/health/browser/patient/files.py
+++ b/bika/health/browser/patient/files.py
@@ -102,6 +102,7 @@ class PatientMultifileView(BikaListingView):
     def folderitem(self, obj, item, index):
         """Augment folder listing item with additional data
         """
+        obj = api.get_object(obj)
         url = item.get("url")
         title = item.get("DocumentID")
 

--- a/bika/health/browser/patients/folder_view.py
+++ b/bika/health/browser/patients/folder_view.py
@@ -207,10 +207,6 @@ class PatientsView(BikaListingView):
             # The current context belongs to a Client, remove the title column
             self.remove_column('getPrimaryReferrerTitle')
 
-    def folderitems(self, full_objects=False, classic=False):
-        # Force the folderitems to work with brains instead of objects
-        return BikaListingView.folderitems(self, classic=classic)
-
     def folderitem(self, obj, item, index):
         # Date of Birth
         dob = obj.getBirthDate

--- a/bika/health/browser/vaccinationcenter/vaccinationcenter.py
+++ b/bika/health/browser/vaccinationcenter/vaccinationcenter.py
@@ -18,10 +18,13 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from bika.lims.browser import BrowserView
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims import bikaMessageFactory as _b
 from bika.health import bikaMessageFactory as _
+from bika.lims import api
+from bika.lims import bikaMessageFactory as _b
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_email_link
+from bika.lims.utils import get_link
+
 
 class ContactsView(BikaListingView):
 
@@ -92,15 +95,10 @@ class ContactsView(BikaListingView):
         # Don't allow any context actions on Vaccination Centers folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-
-            items[x]['replace']['getFullName'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['obj'].getFullname())
-
-            items[x]['replace']['getEmailAddress'] = "<a href='mailto:%s'>%s</a>" % \
-                 (items[x]['getEmailAddress'], items[x]['obj'].getEmailAddress())
-
-        return items
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["replace"].update({
+            "getFullName": get_link(item["url"], obj.getFullName()),
+            "getEmailAddress": get_email_link(obj.getEmailAddress())
+        })
+        return item

--- a/bika/health/controlpanel/bika_aetiologicagents.py
+++ b/bika/health/controlpanel/bika_aetiologicagents.py
@@ -18,16 +18,20 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from Products.ATContentTypes.content import schemata
+from plone.app.content.browser.interfaces import IFolderContentsView
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
 from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
+from zope.interface.declarations import implements
+
 from bika.health import bikaMessageFactory as _
 from bika.health.config import PROJECTNAME
 from bika.health.interfaces import IAetiologicAgents
+from bika.lims import api
 from bika.lims.browser.bika_listing import BikaListingView
-from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
-from plone.app.layout.globals.interfaces import IViewView
-from zope.interface.declarations import implements
+from bika.lims.utils import get_link
 
 
 class AetiologicAgentsView(BikaListingView):
@@ -84,16 +88,12 @@ class AetiologicAgentsView(BikaListingView):
         # Don't allow any context actions on Aetiologic agents folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
 
-        return items
 
 schema = ATFolderSchema.copy()
 class AetiologicAgents(ATFolder):

--- a/bika/health/controlpanel/bika_caseoutcomes.py
+++ b/bika/health/controlpanel/bika_caseoutcomes.py
@@ -18,17 +18,21 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.health.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _b
-from bika.health import bikaMessageFactory as _
-from bika.health.interfaces import ICaseOutcomes
-from plone.app.layout.globals.interfaces import IViewView
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
+
+from bika.health import bikaMessageFactory as _
+from bika.health.config import PROJECTNAME
+from bika.health.interfaces import ICaseOutcomes
+from bika.lims import api
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_link
+
 
 class CaseOutcomesView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -84,16 +88,12 @@ class CaseOutcomesView(BikaListingView):
         # Don't allow any context actions on Case outcomes folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
 
-        return items
 
 schema = ATFolderSchema.copy()
 class CaseOutcomes(ATFolder):

--- a/bika/health/controlpanel/bika_casestatuses.py
+++ b/bika/health/controlpanel/bika_casestatuses.py
@@ -18,17 +18,21 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.health.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _b
-from bika.health import bikaMessageFactory as _
-from bika.health.interfaces import ICaseStatuses
-from plone.app.layout.globals.interfaces import IViewView
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
+
+from bika.health import bikaMessageFactory as _
+from bika.health.config import PROJECTNAME
+from bika.health.interfaces import ICaseStatuses
+from bika.lims import api
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_link
+
 
 class CaseStatusesView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -84,16 +88,12 @@ class CaseStatusesView(BikaListingView):
         # Don't allow any context actions on Case statuses folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
 
-        return items
 
 schema = ATFolderSchema.copy()
 class CaseStatuses(ATFolder):

--- a/bika/health/controlpanel/bika_casesyndromicclassifications.py
+++ b/bika/health/controlpanel/bika_casesyndromicclassifications.py
@@ -18,20 +18,21 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from AccessControl.SecurityInfo import ClassSecurityInfo
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from Products.Archetypes.ArchetypeTool import registerType
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.health.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _b
-from bika.health import bikaMessageFactory as _
-from bika.lims.content.bikaschema import BikaFolderSchema
-from bika.health.interfaces import ICaseSyndromicClassifications
-from plone.app.layout.globals.interfaces import IViewView
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
+
+from bika.health import bikaMessageFactory as _
+from bika.health.config import PROJECTNAME
+from bika.health.interfaces import ICaseSyndromicClassifications
+from bika.lims import api
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_link
+
 
 class CaseSyndromicClassificationsView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -87,16 +88,13 @@ class CaseSyndromicClassificationsView(BikaListingView):
         # Don't allow any context actions on Syndromic classifications folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
-
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
         return items
+
 
 schema = ATFolderSchema.copy()
 class CaseSyndromicClassifications(ATFolder):

--- a/bika/health/controlpanel/bika_diseases.py
+++ b/bika/health/controlpanel/bika_diseases.py
@@ -18,22 +18,21 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from AccessControl.SecurityInfo import ClassSecurityInfo
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from Products.Archetypes.ArchetypeTool import registerType
-from Products.CMFCore.utils import getToolByName
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.health.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _b
-from bika.health import bikaMessageFactory as _
-from bika.lims.content.bikaschema import BikaFolderSchema
-from bika.health.interfaces import IDiseases
-from plone.app.layout.globals.interfaces import IViewView
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
-from operator import itemgetter
+
+from bika.health import bikaMessageFactory as _
+from bika.health.config import PROJECTNAME
+from bika.health.interfaces import IDiseases
+from bika.lims import api
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_link
+
 
 class DiseasesView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -89,16 +88,12 @@ class DiseasesView(BikaListingView):
         # Don't allow any context actions on Diseases folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
 
-        return items
 
 schema = ATFolderSchema.copy()
 class Diseases(ATFolder):

--- a/bika/health/controlpanel/bika_drugprohibitions.py
+++ b/bika/health/controlpanel/bika_drugprohibitions.py
@@ -18,22 +18,21 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from AccessControl.SecurityInfo import ClassSecurityInfo
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from Products.Archetypes.ArchetypeTool import registerType
-from Products.CMFCore.utils import getToolByName
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.health.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _b
-from bika.health import bikaMessageFactory as _
-from bika.lims.content.bikaschema import BikaFolderSchema
-from bika.health.interfaces import IDrugProhibitions
-from plone.app.layout.globals.interfaces import IViewView
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
-from operator import itemgetter
+
+from bika.health import bikaMessageFactory as _
+from bika.health.config import PROJECTNAME
+from bika.health.interfaces import IDrugProhibitions
+from bika.lims import api
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_link
+
 
 class DrugProhibitionsView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -89,16 +88,12 @@ class DrugProhibitionsView(BikaListingView):
         # Don't allow any context actions on Drug Prohibitions folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
 
-        return items
 
 schema = ATFolderSchema.copy()
 class DrugProhibitions(ATFolder):

--- a/bika/health/controlpanel/bika_drugs.py
+++ b/bika/health/controlpanel/bika_drugs.py
@@ -18,22 +18,21 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from AccessControl.SecurityInfo import ClassSecurityInfo
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from Products.Archetypes.ArchetypeTool import registerType
-from Products.CMFCore.utils import getToolByName
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.health.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _b
-from bika.health import bikaMessageFactory as _
-from bika.lims.content.bikaschema import BikaFolderSchema
-from bika.health.interfaces import IDrugs
-from plone.app.layout.globals.interfaces import IViewView
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
-from operator import itemgetter
+
+from bika.health import bikaMessageFactory as _
+from bika.health.config import PROJECTNAME
+from bika.health.interfaces import IDrugs
+from bika.lims import api
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_link
+
 
 class DrugsView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -89,16 +88,12 @@ class DrugsView(BikaListingView):
         # Don't allow any context actions on Drugs folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
 
-        return items
 
 schema = ATFolderSchema.copy()
 class Drugs(ATFolder):

--- a/bika/health/controlpanel/bika_ethnicities.py
+++ b/bika/health/controlpanel/bika_ethnicities.py
@@ -20,6 +20,8 @@
 
 from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
+
+from bika.lims import api
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.health.config import PROJECTNAME
 from bika.health import bikaMessageFactory as _
@@ -28,6 +30,8 @@ from plone.app.layout.globals.interfaces import IViewView
 from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.folder.folder import ATFolder, ATFolderSchema
 from zope.interface.declarations import implements
+
+from bika.lims.utils import get_link
 
 
 class EthnicitiesView(BikaListingView):
@@ -85,16 +89,12 @@ class EthnicitiesView(BikaListingView):
         # Don't allow any context actions on Ethnicities folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                (items[x]['url'], items[x]['Title'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
 
-        return items
 
 schema = ATFolderSchema.copy()
 

--- a/bika/health/controlpanel/bika_identifiertypes.py
+++ b/bika/health/controlpanel/bika_identifiertypes.py
@@ -20,6 +20,8 @@
 
 from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
+
+from bika.lims import api
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.health.config import PROJECTNAME
 from bika.lims import bikaMessageFactory as _b
@@ -29,6 +31,8 @@ from plone.app.layout.globals.interfaces import IViewView
 from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.folder.folder import ATFolder, ATFolderSchema
 from zope.interface.declarations import implements
+
+from bika.lims.utils import get_link
 
 
 class IdentifierTypesView(BikaListingView):
@@ -84,16 +88,12 @@ class IdentifierTypesView(BikaListingView):
         # Don't allow any context actions on Identifier types folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
 
-        return items
 
 schema = ATFolderSchema.copy()
 class IdentifierTypes(ATFolder):

--- a/bika/health/controlpanel/bika_immunizations.py
+++ b/bika/health/controlpanel/bika_immunizations.py
@@ -23,6 +23,8 @@ from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
 from Products.Archetypes.ArchetypeTool import registerType
 from Products.CMFCore.utils import getToolByName
+
+from bika.lims import api
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.health.config import PROJECTNAME
 from bika.lims import bikaMessageFactory as _b
@@ -34,6 +36,9 @@ from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.folder.folder import ATFolder, ATFolderSchema
 from zope.interface.declarations import implements
 from operator import itemgetter
+
+from bika.lims.utils import get_link
+
 
 class ImmunizationsView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -89,16 +94,12 @@ class ImmunizationsView(BikaListingView):
         # Don't allow any context actions on Immunizations folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
 
-        return items
 
 schema = ATFolderSchema.copy()
 class Immunizations(ATFolder):

--- a/bika/health/controlpanel/bika_insurancecompanies.py
+++ b/bika/health/controlpanel/bika_insurancecompanies.py
@@ -18,16 +18,21 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.health.config import PROJECTNAME
-from bika.health import bikaMessageFactory as _
-from bika.health.interfaces import IInsuranceCompanies
-from plone.app.layout.globals.interfaces import IViewView
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
+
+from bika.health import bikaMessageFactory as _
+from bika.health.config import PROJECTNAME
+from bika.health.interfaces import IInsuranceCompanies
+from bika.lims import api
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_link
+
 
 class InsuranceCompaniesView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -98,16 +103,12 @@ class InsuranceCompaniesView(BikaListingView):
         # Don't allow any context actions on Insurance Companies folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Name'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Name'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Name"] = get_link(item["url"], item["Name"])
+        return item
 
-        return items
 
 schema = ATFolderSchema.copy()
 class InsuranceCompanies(ATFolder):

--- a/bika/health/controlpanel/bika_symptoms.py
+++ b/bika/health/controlpanel/bika_symptoms.py
@@ -18,22 +18,22 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from AccessControl.SecurityInfo import ClassSecurityInfo
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from Products.Archetypes.ArchetypeTool import registerType
-from Products.CMFCore.utils import getToolByName
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.health.config import PROJECTNAME, GENDERS_APPLY
-from bika.lims import bikaMessageFactory as _b
-from bika.health import bikaMessageFactory as _
-from bika.lims.content.bikaschema import BikaFolderSchema
-from bika.health.interfaces import ISymptoms
-from plone.app.layout.globals.interfaces import IViewView
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder,ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
-from operator import itemgetter
+
+from bika.health import bikaMessageFactory as _
+from bika.health.config import GENDERS_APPLY
+from bika.health.config import PROJECTNAME
+from bika.health.interfaces import ISymptoms
+from bika.lims import api
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_link
+
 
 class SymptomsView(BikaListingView):
     implements(IFolderContentsView,IViewView)
@@ -95,17 +95,13 @@ class SymptomsView(BikaListingView):
         # Don't allow any context actions on Symptoms folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items=BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj=items[x]['obj']
-            items[x]['Description']=obj.Description()
-            items[x]['Gender']=GENDERS_APPLY.getValue(obj.getGender())
-            items[x]['replace']['Title']="<a href='%s'>%s</a>"%\
-                 (items[x]['url'],items[x]['Title'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["Gender"] = GENDERS_APPLY.getValue(obj.getGender())
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
 
-        return items
 
 schema=ATFolderSchema.copy()
 class Symptoms(ATFolder):

--- a/bika/health/controlpanel/bika_treatments.py
+++ b/bika/health/controlpanel/bika_treatments.py
@@ -23,6 +23,8 @@ from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
 from Products.Archetypes.ArchetypeTool import registerType
 from Products.CMFCore.utils import getToolByName
+
+from bika.lims import api
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.health.config import PROJECTNAME
 from bika.lims import bikaMessageFactory as _b
@@ -34,6 +36,9 @@ from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.folder.folder import ATFolder, ATFolderSchema
 from zope.interface.declarations import implements
 from operator import itemgetter
+
+from bika.lims.utils import get_link
+
 
 class TreatmentsView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -89,16 +94,12 @@ class TreatmentsView(BikaListingView):
         # Don't allow any context actions on Treatments folder
         self.request.set("disable_border", 1)
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
+    def folderitem(self, obj, item, index):
+        obj = api.get_object(obj)
+        item["Description"] = obj.Description()
+        item["replace"]["Title"] = get_link(item["url"], item["Title"])
+        return item
 
-        return items
 
 schema = ATFolderSchema.copy()
 class Treatments(ATFolder):

--- a/bika/health/controlpanel/bika_vaccinationcenters.py
+++ b/bika/health/controlpanel/bika_vaccinationcenters.py
@@ -125,6 +125,7 @@ class VaccinationCentersView(BikaListingView):
             the template
         :index: current index of the item
         """
+        obj = api.get_object(obj)
         name = obj.getName()
         url = api.get_url(obj)
 


### PR DESCRIPTION
Compatibility with https://github.com/senaite/senaite.core/pull/1579

## Description of the issue/feature this PR addresses

This Pull Request removes the "classic" mode from `folderitems` functions to make them compatible with https://github.com/senaite/senaite.core.listing/pull/28

Requires https://github.com/senaite/senaite.core/pull/1579

## Current behavior before PR

Confusing "classic" and "full_objects" params in `folderitems` function

## Desired behavior after PR is merged

Naive `folderitems` function, without parameters

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
