### PR TITLE
Hide url in ClientPatientID column when value is empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #193 Hide url in ClientPatientID column when value is empty
 - #182 Prevent Traceback in patients listing when dob is not set
 - #184 Required patient data can be omitted on save causing error on re-edit
 

--- a/bika/health/browser/patients/folder_view.py
+++ b/bika/health/browser/patients/folder_view.py
@@ -67,17 +67,14 @@ class PatientsView(BikaListingView):
         self.columns = collections.OrderedDict((
             ("Title", {
                 "title": _("Patient"),
-                "index": "getFullname",
-                "replace_url": "absolute_url"}),
+                "index": "getFullname",}),
 
             ('getPatientID', {
                 'title': _('Patient ID'),
-                'index': 'getPatientID',
-                'replace_url': 'getURL'}),
+                'index': 'getPatientID'}),
 
             ('getClientPatientID', {
                 'title': _('Client PID'),
-                'replace_url': 'getURL',
                 'sortable': False}),
 
             ('getGender', {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull request makes the column ClientPatientID to appear empty when the patient does not have value for this field set. The URL to the Patient was displayed before.

## Current behavior before PR

![Captura de 2020-06-11 21-16-10](https://user-images.githubusercontent.com/832627/84429684-e17daa80-ac28-11ea-8ef6-94ac9bac6ee0.png)


## Desired behavior after PR is merged

![Captura de 2020-06-11 21-16-42](https://user-images.githubusercontent.com/832627/84429691-e5113180-ac28-11ea-8efc-549020171946.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
