### PR TITLE
Allow ReferenceWidgetAdapter to be exclusive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #195 Allow Reference Widget adapters to be exclusive
 - #183 Internal Clients functionality
 - #187 Allow to introduce the Age instead of Date of Birth for Patient
 

--- a/bika/health/adapters/referencewidget/__init__.py
+++ b/bika/health/adapters/referencewidget/__init__.py
@@ -39,6 +39,11 @@ class IReferenceWidgetAdapter(IReferenceWidgetVocabulary):
     """
 
 
+class IExclusiveReferenceWidgetAdapter(IReferenceWidgetAdapter):
+    """Marker interface for 'exclusive' reference widget adapters
+    """
+
+
 class ClientAwareReferenceWidgetAdapter(DefaultReferenceWidgetVocabulary):
     """Injects search criteria (filters) in the query when the current context
     is, belongs or is associated to a Client

--- a/bika/health/browser/referencewidget.py
+++ b/bika/health/browser/referencewidget.py
@@ -26,6 +26,7 @@ from bika.health.adapters.referencewidget import IExclusiveReferenceWidgetAdapte
 from bika.lims.browser.widgets.referencewidget import \
     ajaxReferenceWidgetSearch as base
 
+
 class ajaxReferenceWidgetSearch(base):
     """
     End-point for reference widget searches in senaite.health. Does the same

--- a/bika/health/browser/referencewidget.py
+++ b/bika/health/browser/referencewidget.py
@@ -47,11 +47,12 @@ class ajaxReferenceWidgetSearch(base):
         exclusive = filter(lambda ad:
                            IExclusiveReferenceWidgetAdapter.providedBy(ad[1]),
                            adapters)
+
         if exclusive:
             if len(exclusive) > 1:
                 logger.error("Multiple exclusive adapters found!")
-            else:
-                adapters = [exclusive[0]]
+                return []
+            adapters = [exclusive[0]]
 
         brains = []
         for name, adapter in adapters:

--- a/bika/health/browser/referencewidget.py
+++ b/bika/health/browser/referencewidget.py
@@ -44,11 +44,9 @@ class ajaxReferenceWidgetSearch(base):
             return super(ajaxReferenceWidgetSearch, self).search()
 
         # Do not consider other adapters when an "exclusive" adapter is found
-        def is_exclusive(adapter):
-            return IExclusiveReferenceWidgetAdapter.providedBy(adapter[1])
-
-        # Do not consider other adapters if IExclusiveReferenceWidgetVocabulary
-        exclusive = filter(is_exclusive, adapters)
+        exclusive = filter(lambda ad:
+                           IExclusiveReferenceWidgetAdapter.providedBy(ad[1]),
+                           adapters)
         if exclusive:
             if len(exclusive) > 1:
                 logger.error("Multiple exclusive adapters found!")

--- a/bika/health/browser/referencewidget.py
+++ b/bika/health/browser/referencewidget.py
@@ -38,24 +38,35 @@ class ajaxReferenceWidgetSearch(base):
         """Returns the list of brains that match with the request criteria
         """
         params = (self.context, self.request)
-        adapters = list(getAdapters(params, IReferenceWidgetAdapter))
+        adapters = list(getAdapters(params, IReferenceWidgetAdapter)) or []
+
+        # Convert adapters to a list (don't need the name)
+        adapters = map(lambda ad: ad[1], adapters)
+
+        # Filter supported adapters
+        adapters = filter(lambda ad: ad.is_supported(), adapters)
+
         if not adapters:
-            # No health-specific adapters found, fallback to core's defaults
+            # Fallback to core's defaults
             return super(ajaxReferenceWidgetSearch, self).search()
 
         # Do not consider other adapters when an "exclusive" adapter is found
-        exclusive = filter(lambda ad:
-                           IExclusiveReferenceWidgetAdapter.providedBy(ad[1]),
+        exclusive = filter(lambda adapter:
+                           IExclusiveReferenceWidgetAdapter.providedBy(adapter),
                            adapters)
 
-        if exclusive:
-            if len(exclusive) > 1:
-                logger.error("Multiple exclusive adapters found!")
-                return []
+        if exclusive and len(exclusive) > 1:
+            logger.error("Multiple exclusive adapters found!")
+            # We do not fallback to core's default. We return empty to prevent
+            # inconsistencies
+            return []
+
+        elif exclusive:
+            # Discard other adapters
             adapters = [exclusive[0]]
 
         brains = []
-        for name, adapter in adapters:
+        for adapter in adapters:
             brains.extend(adapter())
 
         return brains


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`ReferenceWidgetAdapter` allows to change searches specified in the reference widget on-the-fly. This allows to redefine the search based on current context, on values from other fields, etc. This is mostly used to filter queries by client in different contexts. However, if multiple `ReferenceWidgetAdapters` are found for a given context, the system calls them sequentially and follows an "additive" approach (brains returned by each adapter are being added). 

This Pull Request adds the `IExclusiveReferenceWidgetAdapter`, so when an adapter of this type is found, the system behaves differently by dismissing the rest of adapters.

## Current behavior before PR

System always handle brains returned by `ReferenceWidgetAdapter` in an "additive" manner.

## Desired behavior after PR is merged

System can return a subset of brains when an `IExclusiveReferenceWidgetAdapter` is used.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
