### PR TITLE
Allow to edit the client on batch creation if internal patient

### DIFF
--- a/bika/health/adapters/referencewidget/__init__.py
+++ b/bika/health/adapters/referencewidget/__init__.py
@@ -23,6 +23,7 @@ from zope.interface import implements
 
 from bika.health import logger
 from bika.health.utils import get_client_from_chain
+from bika.health.utils import is_external_client
 from bika.health.utils import resolve_query_for_shareable
 from bika.lims import api
 from bika.lims.adapters.referencewidgetvocabulary import \
@@ -153,8 +154,7 @@ class ClientAwareReferenceWidgetAdapter(DefaultReferenceWidgetVocabulary):
             context_portal_type = api.get_portal_type(self.context)
             if context_portal_type in self.internally_shared_types:
 
-                # Current context can be shared internally (e.g. Batch)
-                if client:
+                if client and is_external_client(client):
                     # Display only the current Client in searches
                     criteria = self.resolve_query(portal_type, client, False)
 

--- a/bika/health/adapters/widgetvisibility/batch.py
+++ b/bika/health/adapters/widgetvisibility/batch.py
@@ -17,8 +17,10 @@
 #
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
+
 from bika.health.interfaces import IDoctor
 from bika.health.interfaces import IPatient
+from bika.health.utils import is_from_external_client
 from bika.lims.adapters.widgetvisibility import SenaiteATWidgetVisibility
 from bika.lims.interfaces import IClient
 
@@ -33,7 +35,10 @@ class ClientFieldVisibility(SenaiteATWidgetVisibility):
 
     def isVisible(self, field, mode="view", default="visible"):
         """Renders the Client field as hidden if the current mode is "edit" and
-        the container is either a Patient or a Client
+        the container is a Patient that belongs to an external client or when
+        the container is a Client. If the container is a Patient that belongs to
+        an internal client, the field is kept editable, cause user might want to
+        assign the batch to an internal client other than the current one.
         """
         if mode == "edit":
             container = self.context.aq_parent
@@ -42,7 +47,10 @@ class ClientFieldVisibility(SenaiteATWidgetVisibility):
             # Doctor make Client field to be rendered, but hidden to prevent
             # the error message "Patient is required, please correct".
             if IPatient.providedBy(container):
-                return "readonly"
+                # User might want to assign the batch to an internal client
+                # other than the Patient's
+                if is_from_external_client(container):
+                    return "readonly"
 
             elif IClient.providedBy(container):
                 return "readonly"

--- a/bika/health/monkeys/batch.py
+++ b/bika/health/monkeys/batch.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.health.interfaces import IPatient
+from bika.health.utils import is_from_external_client
 from bika.lims.interfaces import IClient
 
 
@@ -30,13 +31,15 @@ def getClient(self):
         # The Batch belongs to an External Client
         return parent
 
-    elif IPatient.providedBy(parent):
+    elif IPatient.providedBy(parent) and is_from_external_client(parent):
         # The Batch belongs to a Patient
         return parent.getClient()
 
     parent = self.getField("Client").get(self)
     if parent:
-        # The Batch belongs to an Internal Client
+        # The Batch belongs to an Internal Client, either because is directly
+        # assigned to the Client or because belongs to a Patient from an
+        # internal client
         return parent
 
     # The Batch belongs to the laboratory (no Client assigned)

--- a/bika/health/static/js/bika.health.batch.js
+++ b/bika/health/static/js/bika.health.batch.js
@@ -160,6 +160,10 @@ function HealthBatchEditView() {
         return succeed;
     }
 
+    this.isPatientEditable = function() {
+        return $('#Patient').attr("type") != "hidden";
+    }
+
     this.flushDoctor = function() {
         // Flush doctor field
         $('#Doctor').val('');
@@ -184,8 +188,10 @@ function HealthBatchEditView() {
     function loadEventHandlers() {
         $("#Client").bind("selected paste blur", function(){
             var uid = getElementAttr('#Client', 'uid');
-            // Flush Patient field
-            that.fillPatient(null);
+            // Flush Patient field, but only if is editable!
+            if (that.isPatientEditable()) {
+              that.fillPatient(null);
+            }
             // Flush Doctor field
             that.flushDoctor();
             // Applies the filtering for other client-related fields


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This commit makes the field Client editable in Case (Batch) add form when the parent of the Case is a Patient that belongs to an internal client. Thus, user can assign an internal client other than the one the Patient is assigned to.

Note this only applies in Case creation form, when the parent of the Batch is a Patient that belongs to an internal client and in the Case creation form

## Current behavior before PR

When creating a Case inside a Patient that belongs to an internal client, user cannot assign a client other than the one the Patient is assigned to.

## Desired behavior after PR is merged

When creating a Case inside a Patient that belongs to an internal client, user can modify the client.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
