### PR TITLE
Patient's Datepicker does not translate well

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.2.5 (unreleased)
+------------------
+
+**Fixed**
+
+- #197 Patient's Date time picker does not translates well to current language
+
 1.2.4 (2020-08-11)
 ------------------
 

--- a/bika/health/static/js/bika.health.patient.js
+++ b/bika/health/static/js/bika.health.patient.js
@@ -30,13 +30,7 @@ function HealthPatientEditView() {
         }
 
         // Adapt datepicker to current needs
-        $("#BirthDate").datepicker("destroy");
-        $("#BirthDate").datepicker({
-            dateFormat: "yy-mm-dd",
-            changeMonth:true,
-            changeYear:true,
-            yearRange: "-100:+0"
-        });
+        $("#BirthDate").datepicker("option", "yearRange", "-100:+0" );
 
         if ($('#patient-base-edit')) {
             loadAnonymous();


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the datepicker from Patient view (Date of birth) to be rendered with the current's user language.
See: https://github.com/senaite/senaite.core/pull/1570

## Current behavior before PR

The Datepicker from Birth Date (Patient view) is displayed in Corean? although the language set is English.

## Desired behavior after PR is merged

Date picker is rendered with current's user language

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
