### PR TITLE
Remove memoize from patients folder view

### DIFF
--- a/bika/health/browser/patients/folder_view.py
+++ b/bika/health/browser/patients/folder_view.py
@@ -152,7 +152,6 @@ class PatientsView(BikaListingView):
         """
         return get_client_from_chain(self.context)
 
-    @view.memoize
     def get_user_client(self):
         """Returns the client from current user, if any
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

There is a `vew.memoize`decorator that was preventing the view to get the client form the client contact.

This is done in the following line: https://github.com/senaite/senaite.health/blob/1.x/bika/health/browser/patients/folder_view.py#L196

I am not sure to understand how memoize works, but after removing the decorator the issue was fixed. Also, considering that a Client is obtained from the Client Contact parent object, the process may not be heavy enough to make use of memoize.

## Current behavior before PR

`self.get_user_client()` returns `None` while `api.get_user_client()` returns the proper value.

## Desired behavior after PR is merged

`self.get_user_client()` to return the Client that the client contact belongs to.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
