### PR TITLE
Compatibility with core#1717

### DIFF
--- a/src/bika/health/impress/reports/Default.pt
+++ b/src/bika/health/impress/reports/Default.pt
@@ -415,7 +415,7 @@
           </tr>
           <tr>
             <td class="label" i18n:translate="">Date Verified</td>
-            <td tal:content="python:view.to_localized_time(model.get_transition_date('bika_ar_workflow', 'verified'))"></td>
+            <td tal:content="python:view.to_localized_time(model.getDateVerified())"></td>
           </tr>
           <tr>
             <td class="label" i18n:translate="">Date Published</td>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes senaite.health compatible with https://github.com/senaite/senaite.core/pull/1717

## Current behavior before PR

Default report relies on `bika_ar_workflow`

## Desired behavior after PR is merged

Default report relies does no longer rely `bika_ar_workflow`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
