### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "archetypes.schemaextender",
         "senaite.lims>=1.3.4",
         "senaite.lims<1.4.0",
-        "senaite.panic",
+        "senaite.panic<1.2.0",
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
added a change in line 40 "senaite.panic<1.2.0"
we get an error
Error: There is a version conflict.
We already have: senaite.lims 1.3.4
but senaite.panic 2.0.0 requires 'senaite.lims>=2.0.0rc1'

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.health/issues/

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
