### PR TITLE
Fix persistent broken content.analysisspec.AnalysisSpec instance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.2.6 (unreleased)
 ------------------
 
+- #205 Fix persistent broken content.analysisspec.AnalysisSpec instance
+
 
 1.2.5 (2021-07-23)
 ------------------

--- a/bika/health/content/analysisspec.py
+++ b/bika/health/content/analysisspec.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.HEALTH.
+#
+# SENAITE.HEALTH is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2021 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+# This is required for backward compatibility because of
+# https://github.com/senaite/senaite.health/commit/dff79cf234c647c0e6c03158e6708d3a7d774ddb
+from bika.lims.content.analysisspec import AnalysisSpec  # noqa


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

health-specific AnalysisSpec content type was removed on dff79cf23 ,but existing objects weren't ported. Thus, the system gives a persistent broken error when trying to wake-up objects of this type.

## Current behavior before PR

When trying to navigate to an Analysis Specification object

```
<persistent broken bika.health.content.analysisspec.AnalysisSpec instance '\\x00\\x00\\x00\\x00\\x07\\xc3\\xe7\\x82'> is not supported.
```

Also, the following traceback was arising on specs listing:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module senaite.core.listing.view, line 214, in __call__
  Module senaite.core.listing.ajax, line 103, in handle_subpath
  Module senaite.core.listing.decorators, line 63, in wrapper
  Module senaite.core.listing.decorators, line 50, in wrapper
  Module senaite.core.listing.decorators, line 100, in wrapper
  Module senaite.core.listing.ajax, line 528, in ajax_folderitems
  Module senaite.core.listing.decorators, line 88, in wrapper
  Module senaite.core.listing.ajax, line 307, in get_folderitems
  Module senaite.core.listing.view, line 895, in folderitems
  Module bika.lims.controlpanel.bika_analysisspecs, line 122, in folderitem
AttributeError: Title
```

## Desired behavior after PR is merged

User can navigate to Analysis Specifications without errors

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
